### PR TITLE
feat: Major grid-cli refactor with project-name flag, gateway network extension, and agent improvements

### DIFF
--- a/agent/pkg/config/config.go
+++ b/agent/pkg/config/config.go
@@ -13,7 +13,7 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		SystemPrompt:     "You are a helpful AI assistant. You can use tools to help the user.",
-		ModelName:        "gemini-2.5-flash",
+		ModelName:        "gemini-3-flash-preview",
 		ResponseMIMEType: "application/json",
 		MaxRetries:       3,
 		MaxJSONRetries:   2,

--- a/agent/pkg/llm/gemini.go
+++ b/agent/pkg/llm/gemini.go
@@ -40,7 +40,7 @@ func NewGeminiProvider(apiKey string, modelName string) (*GeminiProvider, error)
 	}
 
 	if modelName == "" {
-		config.ModelName = "gemini-2.5-flash"
+		config.ModelName = "gemini-3-flash-preview"
 	}
 
 	return NewGeminiProviderWithConfig(apiKey, config)
@@ -59,7 +59,7 @@ func NewGeminiProviderWithConfig(apiKey string, config Config) (*GeminiProvider,
 	}
 
 	if config.ModelName == "" {
-		config.ModelName = "gemini-2.5-flash"
+		config.ModelName = "gemini-3-flash-preview"
 	}
 
 	provider := &GeminiProvider{

--- a/agent/pkg/llm/prompts.go
+++ b/agent/pkg/llm/prompts.go
@@ -4,7 +4,7 @@ package llm
 const JSONFormatInstructions = `
 ## RESPONSE FORMAT STANDARDS
 
-You **MUST** reply with a **SINGLE** JSON object or an **ARRAY** of JSON objects. **NO extra text or formatting** outside of the JSON structure is allowed.
+You **MUST** reply with a **SINGLE** JSON object. **NO extra text or formatting** outside of the JSON structure is allowed.
 
 The available tools and their specific formats are described in the relevant section below.
 
@@ -29,6 +29,7 @@ Use this format for your complete, final response to the user:
   "answer": "Your complete, formatted response to the user here.",
   "explanation": "Relevant context, reasoning, or command results supporting the answer."
 }
+
 
 ## CRITICAL RULES
 

--- a/grid-agent-gui/app.go
+++ b/grid-agent-gui/app.go
@@ -624,7 +624,7 @@ func (a *App) initializeAgent(opts AgentInitOptions) error {
 	}
 
 	// Determine model
-	modelName := "gemini-2.5-flash"
+	modelName := "gemini-3-flash-preview"
 	if a.settings.Model != "" {
 		modelName = a.settings.Model
 	}

--- a/grid-agent-gui/frontend/src/components/Settings.svelte
+++ b/grid-agent-gui/frontend/src/components/Settings.svelte
@@ -62,6 +62,7 @@
 
   const availableModels = [
     "gemini-3-pro-preview",
+    "gemini-3-flash-preview",
     "gemini-2.5-pro",
     "gemini-2.5-flash",
     "gemini-2.5-flash-lite",

--- a/grid-agent-gui/go.mod
+++ b/grid-agent-gui/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/samber/lo v1.49.1 // indirect
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30 // indirect
 	github.com/threefoldtech/tfgrid-sdk-go/grid-client v0.17.5 // indirect
-	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.0 // indirect
+	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.5 // indirect
 	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.5 // indirect
 	github.com/threefoldtech/zosbase v1.0.4 // indirect
 	github.com/tkrajina/go-reflector v0.5.8 // indirect

--- a/grid-agent-gui/go.sum
+++ b/grid-agent-gui/go.sum
@@ -172,8 +172,8 @@ github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
 github.com/threefoldtech/tfgrid-sdk-go/grid-client v0.17.5 h1:uyLQNxE6DikMsi7AujbBY6bZWSTRMAnBPXJE5iT5K/U=
 github.com/threefoldtech/tfgrid-sdk-go/grid-client v0.17.5/go.mod h1:pDqAGlLPD1LyBvJy90B7DhQ5HWGrz2tyj1YNO6Cc6tI=
-github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.0 h1:Z5IlF+B0N02myvos8TjsVZbF/VkFCJ7CbEUJwMyLnF4=
-github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.0/go.mod h1:DWvKZtNjED/soFjKs1zUcOtPCf52uVjj94SyFtaLsas=
+github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.5 h1:ZHjXH/b9MLFKMhtDBfVPov/UjBwpjFDB+J0m2Tz1BA0=
+github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.5/go.mod h1:VxjCKht0QTbwZd4LkhIhIinLKHCP5xYjXMoSgdbHmS8=
 github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.5 h1:zp5iZOvtvcQrcR7Po3UZBNk2uBYi1i1VxMA/ENIvCZY=
 github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.5/go.mod h1:T+PZydVl3fxywqoUhCmzs+hUarfE1q9IMRl9xa+GIYo=
 github.com/threefoldtech/zosbase v1.0.4 h1:A4kFukh4IO5r5e9F51aqKgXOyTG5cWknxqEVGtQ647w=

--- a/grid-agent-gui/internal/config/prompt.go
+++ b/grid-agent-gui/internal/config/prompt.go
@@ -9,93 +9,110 @@ import (
 func GetSystemPrompt(network string, instructions string) string {
 	basePrompt := fmt.Sprintf(`# TF-Grid CLI Intelligent Agent
 
-You are an intelligent agent for the tf-grid CLI running on %s. Help the user interact with the CLI using natural language while executing commands autonomously and providing consultative advice.
+You are an expert autonomous agent for the tf-grid CLI running on %s. Your role is to help users interact with the CLI using natural language, execute commands autonomously, and provide consultative technical advice.
 
-## CORE CAPABILITIES
+## YOUR CORE ROLE & CAPABILITIES
 
-* **System Commands:** Execute **ANY** read-only and safe system command, including file operations, SSH, kubectl, and shell commands—not just tfcmd.
-* **CLI Preference:** Prefer tfcmd CLI commands whenever possible.
-* **Tool Access:** {{TOOL_DESCRIPTIONS}}
+**Primary Function:** Translate natural language requests into tf-grid CLI operations while educating users about their options.
 
-## CRITICAL CONTEXT & BEHAVIOR
+**Available Tools:** {{TOOL_DESCRIPTIONS}}
 
-### Network Context
-* Operating on the '%s' network. Confirm this whenever asked.
+**Command Execution:**
+- Execute ANY read-only and safe system commands (file operations, SSH, kubectl, shell commands)
+- **Always prefer tfcmd CLI commands** when available
+- Operating on '%s' network (confirm when asked)
 
-### Proactive & Autonomous Execution
-* Try to complete tasks without asking for more info.
-* If issues arise (missing files, SSH key, env vars), attempt automated resolution:
-  1. List relevant files/directories.
-  2. Use reasonable defaults or first available resource.
-  3. Only ask the user if no automatic solution exists.
-* Respect instructions like "use my default X" — do **not** ask for X again.
-* Never execute destructive operations without **clear, unambiguous confirmation**.
-* Never run commands with missing required flags — always request them first.
-* Consider prior conversation context when relevant.
+## AUTONOMOUS EXECUTION PROTOCOL
 
-## DATA DISPLAY RULES
+**Proactive Problem-Solving:**
+1. Complete tasks without requesting additional information when possible
+2. When issues arise (missing files, SSH keys, env vars):
+   - List relevant files/directories automatically
+   - Apply reasonable defaults or first available resource
+   - Only ask user if no automatic solution exists
+3. Respect user preferences (e.g., "use my default X") - never re-ask
+4. Consider full conversation history for context
 
-* When listing resources (contracts, nodes, twins, etc.), include the **FULL processed list** in the answer.
-* **Do not summarize**. Copy all relevant output from the tool.
+**Safety Rules:**
+- NEVER execute destructive operations without explicit user confirmation
+- NEVER run commands with missing required flags - always request them first
+- ALWAYS confirm before: deleting, modifying, or deploying resources
 
-## CONSULTATIVE DEPLOYMENT & FLIST RULES
+## OUTPUT FORMAT SPECIFICATIONS
 
-### General Deployment Workflow
-1. Lookup latest flist URL from official Hub.
-2. Extract env vars / entrypoint from GitHub.
-3. Combine: full official flist URL + env vars + entrypoint.
+**Resource Listings:**
+- Format: Structured table with all fields
+- Include FULL processed list from tool output
+- Never summarize or truncate results
 
-### General Resources (VM, Kubernetes, Gateway, ZDB)
-1. Lookup latest flist URL from official Hub.
-2. Gather **all required info**.
-3. Ask about **optional configurations**, showing **default values clearly**.
-4. Only execute after user confirmation.
+**Deployment Confirmations:**
+- Show all configuration parameters with labels
+- Highlight required vs optional fields
+- Display default and recommended values clearly
 
-### Application Deployments (WordPress, Presearch, etc.)
-1. Lookup latest flist URL from official Hub.
-2. Lookup **README.md** in GitHub for required env vars and flist.
-3. Gather all required info including env vars.
-4. Ask about optional resource configuration, showing **default values and recommended values clearly if available**.
-5. Deploy only after user confirms.
+## DEPLOYMENT WORKFLOW
+1. Lookup latest flist URL from official Hub API: for applications https://hub.grid.tf/api/flist/tf-official-apps and for OS base images https://hub.grid.tf/api/flist/tf-official-vms
+2. Fetch image info from GitHub for env vars, entrypoint, and hardware requirements:
+   - Primary: https://raw.githubusercontent.com/threefoldtech/grid-agent/development/knowledge/SOLUTIONS_CATALOG.md (this should be sufficient for most cases)
+   - Secondary: https://raw.githubusercontent.com/threefoldtech/tf-images/development/tfgrid3/<solution>/README.md (this should be used as a fallback)
+     - Fallback: INSTALL.md, CONFIG.md
+     - If exact name fails, list tfgrid3 directory contents to locate correct solution
+3. Combine: full flist URL + env vars + entrypoint + other info and hardware requirements from the image info
+4. Present complete configuration with defaults
+5. Deploy after confirmation
 
 ### Flist Version Selection
-* If no version specified, pick **latest updated flist** from official Hub APIs.
-* If multiple flists have same timestamp, prefer **non-versioned generic flist**.
+- Default: Latest updated flist from official Hub APIs
+- If timestamps match: prefer non-versioned generic flist
 
-## EXTERNAL INFORMATION
+## EXTERNAL DATA SOURCES
 
-### Official Hub APIs (Always Prioritize)
-* OS flists: https://hub.grid.tf/api/flist/tf-official-vms
-* App flists: https://hub.grid.tf/api/flist/tf-official-apps
-* Construct full URL: https://hub.grid.tf/tf-official-apps/<flist_name>
+**Official Hub APIs (Primary):**
+- OS flists: https://hub.grid.tf/api/flist/tf-official-vms
+- App flists: https://hub.grid.tf/api/flist/tf-official-apps
+- Full URL format: https://hub.grid.tf/tf-official-apps/<flist_name>
 
-### GitHub & Documentation
-* App deployment info: https://api.github.com/repos/threefoldtech/tf-images/contents/tfgrid3
-  - Check for the solution directory within the tfgrid3 folder. Name sometimes can be slightly different.
-  - If looking up the dir by exact solution name didn't work, attempt to list the contents of the tfgrid3 directory to see available subdirectories and locate the correct solution one.
-  - Use README.md first (e.g. https://raw.githubusercontent.com/threefoldtech/tf-images/development/tfgrid3/alpine/README.md); fallback to other .md files (INSTALL.md, CONFIG.md) for env vars and entrypoint.
-* Grid CLI docs: https://github.com/threefoldtech/tfgrid-sdk-go/blob/development/grid-cli/README.md
-* Grid manual: https://manual.grid.tf/documentation/
+**GitHub Documentation:**
+- App info: https://api.github.com/repos/threefoldtech/tf-images/contents/tfgrid3
+- Grid CLI docs: https://github.com/threefoldtech/grid-agent/blob/development/grid-cli/README.md
+- Grid manual: https://manual.grid.tf/documentation/
 
-### GridProxy API
-* Swagger: https://gridproxy[.dev|.qa|.test].grid.tf/swagger/doc.json
-* Use cases: find and list nodes, farms, contracts, twins, IP addresses; get stats, twin info, consumption, bills.
-* Confirm network with user if unclear.
-* You must fetch swagger schema to learn about available endpoints, parameters, and responses before attempt to call any endpoint.
-* You must ensure efficient and accurate data retrieval by composing the API query using the relevant available endpoint parameters and sorting options.
-* When dealing with user contracts you must remember to use twin_id parameter.
-* When filtering nodes for deployment you must use "status" and "healthy" parameters. Do not use the "rentable" parameter unless you are planning to rent the entire node.
-* Apply pagination (page, size) to fetch complete results when needed.
-* Bills unit is unit-TFT (1 TFT = 10,000,000 unit-TFT). Use CoinGecko API to get the exchange rate of TFT in USD when needed.
+**GridProxy API:**
+- Swagger: https://gridproxy[.dev|.qa|.test].grid.tf/swagger/doc.json
+- **Always fetch swagger schema first** before calling endpoints
+- Use cases: nodes, farms, contracts, twins, IPs, stats, consumption, bills
+- Query optimization: Always use relevant parameters, sorting, and pagination (page, size)
+- Node filtering: use "status" and "healthy" parameters (NOT "rentable" unless renting entire node)
+- Contract queries: include twin_id parameter
+- Bills: unit-TFT (1 TFT = 10,000,000 unit-TFT) - use CoinGecko API for USD conversion
 
-## FAILSAFE & CONSULTATIVE BEHAVIOR
+## INTERACTION EXAMPLES
 
-* Attempt automated solutions before asking questions.
-* If missing info cannot be resolved automatically, request it from user.
-* Educate users about options, defaults, and implications.
-* Always confirm destructive actions explicitly.
-* Check previous context, but never assume unstated preferences.
-* Be consultative and educational — help users understand their options.`, runtime.GOOS, network)
+**Example 1 - Simple Query:**
+User: "Show me my active contracts"
+Agent: [Executes tfcmd contract list, displays full formatted results]
+
+**Example 2 - Deployment with Defaults:**
+User: "Deploy an <solution-name> instance"
+Agent: "I'll deploy <solution-name> with these configurations:
+- Flist: https://hub.grid.tf/tf-official-apps/<solution-name>-latest.flist
+- CPU: 2 cores [recommended: 4]
+- Memory: 4GB [recommended: 8GB]
+- Storage: 50GB
+Required env vars: <env-vars>
+Would you like to proceed or modify any settings?"
+
+**Example 3 - Autonomous Problem-Solving:**
+User: "SSH into my VM using my default key"
+Agent: [Lists ~/.ssh/, finds id_rsa, executes SSH without asking]
+
+## CONSULTATIVE APPROACH
+
+- Educate users about options, trade-offs, and implications
+- Explain defaults and why they're recommended
+- Provide context for technical decisions
+- Be proactive but never assume unstated preferences
+- Confirm understanding before executing complex operations`, runtime.GOOS, network)
 
 	if instructions != "" {
 		basePrompt += fmt.Sprintf("\n\n## USER CUSTOM INSTRUCTIONS:\n- Prioritize user instruction below\n%s", instructions)

--- a/grid-agent-gui/internal/config/prompt.go
+++ b/grid-agent-gui/internal/config/prompt.go
@@ -84,7 +84,7 @@ You are an intelligent agent for the tf-grid CLI running on %s. Help the user in
 * You must fetch swagger schema to learn about available endpoints, parameters, and responses before attempt to call any endpoint.
 * You must ensure efficient and accurate data retrieval by composing the API query using the relevant available endpoint parameters and sorting options.
 * When dealing with user contracts you must remember to use twin_id parameter.
-* When filter nodes for deployment you shoud use "status" and "healthy" parameters. "rentable" is not required if you are not renting the whole node.
+* When filtering nodes for deployment you must use "status" and "healthy" parameters. Do not use the "rentable" parameter unless you are planning to rent the entire node.
 * Apply pagination (page, size) to fetch complete results when needed.
 * Bills unit is unit-TFT (1 TFT = 10,000,000 unit-TFT). Use CoinGecko API to get the exchange rate of TFT in USD when needed.
 

--- a/grid-agent-gui/internal/tfcmd/tool.go
+++ b/grid-agent-gui/internal/tfcmd/tool.go
@@ -61,60 +61,79 @@ func (t *Tool) Description() tools.ToolDescriptor {
   "arguments": ["tfcmd", "deploy", "vm", "--name", "myvm"],
   "explanation": "explain why you need to execute this command"
 }`,
-		Instructions: fmt.Sprintf(`Use this tool to interact with the ThreeFold Grid.
-- Deploy and manage VMs, Kubernetes clusters, gateways, and ZDBs
-- Query and cancel contracts
-- All tfcmd commands are available
+		Instructions: fmt.Sprintf(`Execute ThreeFold Grid CLI commands using the provided schema.
 
-VALIDATION RULES:
-- Check that ALL required flags are provided (look for "required": true in the schema)
-- Check that ALL required positional arguments are provided (look for "args" in the schema)
-- Evaluate the 'Mutually Exclusive Flags' and 'Flag Groups' sections for the target subcommand.
-- If any required flags or arguments are missing, ask the user first
-- resources names must contain only letters and numbers
-- Always remember that deploy kubernetes|vm --ssh flag takes the file path not the file content
+VALIDATION CHECKLIST:
+- You MUST use alphanumeric only for deployment and project names
+- You MUST provide all required flags (check "required": true in schema)
+- You MUST provide required positional args (check "args" in schema)  
+- You MUST satisfy flag groups (see FLAG GROUPS below)
+- You MUST respect mutually exclusive flags (see EXCLUSIONS below)
+- You MUST use file path for --ssh flag, not key content
+
+CRITICAL FLAG RULES:
 
 FLAG GROUPS (must be set together):
-- deploy vm: if --flist is provided, --entrypoint MUST also be provided
+- deploy vm: --flist + --entrypoint (both required if either is used)
 
-MUTUALLY EXCLUSIVE FLAGS (only ONE can be set):
-- deploy vm: --node OR --farm (not both)
-- deploy kubernetes: --master-node OR --master-farm (not both)
-- deploy kubernetes: --workers-nodes OR --workers-farm (not both)
-- deploy gateway name: --node OR --farm (not both)
-- deploy zdb: --node OR --farm (not both)
+EXCLUSIONS (only ONE can be set):
+- deploy vm: --node OR --farm (never both)
+- deploy kubernetes: --master-node OR --master-farm
+- deploy kubernetes: --workers-nodes OR --workers-farm  
+- deploy gateway name: --node OR --farm
+- deploy gateway fqdn: --node OR --farm
+- deploy zdb: --node OR --farm
 
-BOOLEAN FLAG SYNTAX:
-- To enable: --flag or --flag=true
-- To disable: --flag=false (MUST use = sign)
+BOOLEAN FLAGS:
+- Enable: --flag or --flag=true
+- Disable: --flag=false (equals sign REQUIRED)
 - WRONG: --mycelium false
-- CORRECT: --mycelium=false
+- RIGHT: --mycelium=false
 
-SSH KEYS IN ENV VARS:
-- Some flists require SSH key as ENV VAR (e.g., SSH_KEY, pub_key)
-- For ENV VAR: pass the actual key CONTENT, not the file path
+SSH & ENVIRONMENT:
+- --ssh flag: file path (e.g., ~/.ssh/id_rsa.pub)
+- ENV vars like SSH_KEY: actual key content, not file path
 
-CANCEL/DELETE:
-- By name: tfcmd cancel <deployment-name> (preferred for single deployments)
-- By contract: tfcmd cancel contracts <contract-id>
-- Cancel all: tfcmd cancel contracts -a (REQUIRES explicit user confirmation!)
 
-OTHER RELEVANT INFORMATION:
-- Don't Ask user for his twin ID, instead look it up as it it usually can be seen in the output of tfcmd, such "get contracts", etc.
-- Always use --disable-sentry with any deploy commands unless user specified otherwise
+PRO TIPS:
+- Find twin ID from "get contracts" output - don't ask user
+
+DOMAIN PLANNING PATTERN (breaks circular dependency):
+1. List available gateways and pick node:
+   tfcmd list gateways name --farm 1
+
+2. Plan your full domain (gateway domain + your subdomain):
+   If gateway shows: "gent01.dev.grid.tf"
+   Your planned domain: "myapp.gent01.dev.grid.tf"
+
+3. Deploy VM with planned domain in env vars:
+   tfcmd deploy vm --name api --project-name myapp --env DOMAIN=myapp.gent01.dev.grid.tf
+
+4. Get VM IP after deployment:
+   tfcmd get vm api --project-name myapp
+   Note the private IP: e.g., 10.20.2.2
+
+5. Deploy gateway to planned node with backend IP:
+   tfcmd deploy gateway name --name myapp --node <gateway-node-id> --backends http://10.20.2.2:8080 --project-name myapp
+
+This allows configuring app with domain before gateway exists!
 
 %s`, schemaJSON),
 		Examples: []string{
 			`{
   "toolName": "tfcmd",
-  "arguments": ["tfcmd", "list"]
+  "arguments": ["tfcmd", "list", "gateways", "name"]
+}`,
+			`{
+  "toolName": "tfcmd", 
+  "arguments": ["tfcmd", "deploy", "vm", "--name", "myvm", "--ssh", "~/.ssh/id_rsa.pub", "--cpu", "2", "--memory", "4"]
 }`,
 			`{
   "toolName": "tfcmd",
-  "arguments": ["tfcmd", "deploy", "vm", "--name", "myvm", "--ssh", "~/.ssh/id_rsa.pub"]
+  "arguments": ["tfcmd", "deploy", "gateway", "name", "--name", "myapp", "--node", "11", "--backends", "http://10.20.2.2:8080", "--network", "mynetwork", "--project-name", "myapp"]
 }`,
 		},
-		ProgressText: "⚡ Command Executed",
+		ProgressText: "Command Executed",
 		ExportPrefix: "Command:",
 	}
 }

--- a/grid-agent-gui/internal/tfcmd/tool.go
+++ b/grid-agent-gui/internal/tfcmd/tool.go
@@ -100,7 +100,7 @@ CANCEL/DELETE:
 - Cancel all: tfcmd cancel contracts -a (REQUIRES explicit user confirmation!)
 
 OTHER RELEVANT INFORMATION:
-- Don't Ask user for his twin ID, instead look it up as it it usually can be seen in the output of tfcmd, such "get" or "contracts", etc.
+- Don't Ask user for his twin ID, instead look it up as it it usually can be seen in the output of tfcmd, such "get contracts", etc.
 - Always use --disable-sentry with any deploy commands unless user specified otherwise
 
 %s`, schemaJSON),

--- a/grid-cli/README.md
+++ b/grid-cli/README.md
@@ -23,7 +23,68 @@ For examples and description of tfcmd commands check out:
 - [gateway-name](docs/gateway-name.md)
 - [kubernetes](docs/kubernetes.md)
 - [ZDB](docs/zdb.md)
-- [chat](docs/chat.md)
+- [cancel](docs/cancel.md)
+- [get](docs/get.md)
+- [list](docs/list.md)
+- [login](docs/login.md)
+- [update](docs/update.md)
+- [version](docs/version.md)
+- [contracts](docs/contracts.md)
+
+## Quick Examples
+
+```bash
+# Login to ThreeFold Grid
+tfcmd login
+
+# Deploy a VM
+tfcmd deploy vm --name myvm --ssh ~/.ssh/id_rsa.pub --cpu 2 --memory 4
+
+# Get VM information
+tfcmd get vm myvm --project-name vm/myvm
+
+# List available gateways
+tfcmd list gateways name
+
+# Deploy a gateway name
+tfcmd deploy gateway name --name myapp --node 11 --backends http://10.20.2.2:8080
+
+# Cancel deployment
+tfcmd cancel --project-name vm/myvm
+```
+
+## Command Reference
+
+```bash
+tfcmd
+├── deploy
+│   ├── vm              # Deploy virtual machines
+│   ├── gateway
+│   │   ├── name        # Deploy name gateway (subdomain)
+│   │   └── fqdn        # Deploy FQDN gateway
+│   ├── kubernetes      # Deploy Kubernetes clusters
+│   └── zdb             # Deploy Zero-DB instances
+├── get
+│   ├── vm              # Get VM information
+│   ├── gateway
+│   │   ├── name        # Get name gateway info
+│   │   └── fqdn        # Get FQDN gateway info
+│   ├── kubernetes      # Get Kubernetes cluster info
+│   ├── zdb             # Get ZDB instance info
+│   ├── contract        # Get specific contract info
+│   └── contracts       # List all contracts
+├── list
+│   └── gateways
+│       ├── name        # List name gateways
+│       └── fqdn        # List FQDN gateways
+├── cancel
+│   └── contracts       # Cancel contracts
+├── update
+│   └── kubernetes      # Update Kubernetes workers
+├── login               # Authenticate with mnemonics
+├── version             # Show version information
+└── completion          # Generate shell completions
+```
 
 ## Download
 

--- a/grid-cli/cmd/cancel.go
+++ b/grid-cli/cmd/cancel.go
@@ -130,8 +130,8 @@ func loadProjectVMs(ctx context.Context, t deployer.TFPluginClient, projectName 
 			continue
 		}
 
-		// Skip network contracts - we only want VM deployments
-		if deploymentData.Type == "network" {
+		// Only load VM deployments - skip networks, gateways, etc.
+		if deploymentData.Type != workloads.VMType {
 			continue
 		}
 

--- a/grid-cli/cmd/deploy_gateway.go
+++ b/grid-cli/cmd/deploy_gateway.go
@@ -29,6 +29,8 @@ func init() {
 	}
 
 	deployGatewayCmd.PersistentFlags().Bool("tls", false, "add tls passthrough")
+	deployGatewayCmd.PersistentFlags().String("network", "", "network name (optional, for reference - gateway proxies to backend IP)")
+	deployGatewayCmd.PersistentFlags().String("project-name", "", "project name for grouping deployments (required when using --network)")
 }
 
 func parseCommonGatewayFlags(cmd *cobra.Command) (
@@ -36,6 +38,8 @@ func parseCommonGatewayFlags(cmd *cobra.Command) (
 	tls bool,
 	zosBackends []zos.Backend,
 	node uint32,
+	network string,
+	projectName string,
 	err error,
 ) {
 	name, err = cmd.Flags().GetString("name")
@@ -54,6 +58,14 @@ func parseCommonGatewayFlags(cmd *cobra.Command) (
 		zosBackends = append(zosBackends, zos.Backend(backend))
 	}
 	node, err = cmd.Flags().GetUint32("node")
+	if err != nil {
+		return
+	}
+	network, err = cmd.Flags().GetString("network")
+	if err != nil {
+		return
+	}
+	projectName, err = cmd.Flags().GetString("project-name")
 	if err != nil {
 		return
 	}

--- a/grid-cli/cmd/deploy_gateway_fqdn.go
+++ b/grid-cli/cmd/deploy_gateway_fqdn.go
@@ -20,9 +20,27 @@ var deployGatewayFQDNCmd = &cobra.Command{
 
 Use your own domain name. You must configure DNS to point to the gateway node.
 
+IMPORTANT: Gateway must be able to reach your backend. Choose ONE option:
+
+1️⃣ SAME NETWORK: Deploy gateway and VM on same network
+   tfcmd deploy vm --name webapp --project-name myapp --ssh ~/.ssh/id_rsa.pub
+   tfcmd deploy gateway fqdn --name api --fqdn api.example.com --node 11 --backends http://10.20.2.2:8080 --network myappnetwork --project-name myapp
+
+2️⃣ SAME NODE: Deploy gateway and VM on same node
+   tfcmd deploy vm --name webapp --node 11 --ssh ~/.ssh/id_rsa.pub
+   tfcmd deploy gateway fqdn --name api --fqdn api.example.com --node 11 --backends http://10.20.2.2:8080
+
+3️⃣ PUBLIC IP: Use VM's public IP as backend
+   tfcmd deploy vm --name webapp --ipv4 --ssh ~/.ssh/id_rsa.pub
+   tfcmd deploy gateway fqdn --name api --fqdn api.example.com --node 11 --backends http://<VM-PUBLIC-IP>:8080
+
+4️⃣ PLANETARY/MYCELIUM: Use planetary or mycelium IP
+   tfcmd deploy vm --name webapp --ssh ~/.ssh/id_rsa.pub
+   tfcmd deploy gateway fqdn --name api --fqdn api.example.com --node 11 --backends http://<VM-PLANETARY-IP>:8080
+
 Examples:
-  # Deploy gateway with custom domain
-  tfcmd deploy gateway fqdn --name myapp --fqdn myapp.example.com --node 14 --backends http://10.20.2.2:8080`,
+  # Option 1: Same network (recommended for multi-VM)
+  tfcmd deploy gateway fqdn --name myapp --fqdn myapp.example.com --node 11 --backends http://10.20.2.2:8080 --network myappnetwork --project-name myapp`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name, tls, zosBackends, node, network, projectName, err := parseCommonGatewayFlags(cmd)
 		if err != nil {

--- a/grid-cli/cmd/deploy_gateway_fqdn.go
+++ b/grid-cli/cmd/deploy_gateway_fqdn.go
@@ -2,6 +2,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	command "github.com/threefoldtech/grid-agent/grid-cli/internal/cmd"
@@ -14,15 +16,15 @@ import (
 var deployGatewayFQDNCmd = &cobra.Command{
 	Use:   "fqdn",
 	Short: "Deploy a gateway FQDN proxy",
-	Long: `Deploy a gateway FQDN proxy for your custom domain.
+	Long: `Deploy a gateway FQDN proxy for custom domains.
 
-Requires you to own a domain and point it to the gateway node's IP.
+Use your own domain name. You must configure DNS to point to the gateway node.
 
 Examples:
   # Deploy gateway with custom domain
-  tfcmd deploy gateway fqdn --name myapp --fqdn myapp.example.com --backends http://10.20.2.2:8000 --node 14`,
+  tfcmd deploy gateway fqdn --name myapp --fqdn myapp.example.com --node 14 --backends http://10.20.2.2:8080`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		name, tls, zosBackends, node, err := parseCommonGatewayFlags(cmd)
+		name, tls, zosBackends, node, network, projectName, err := parseCommonGatewayFlags(cmd)
 		if err != nil {
 			return err
 		}
@@ -30,6 +32,17 @@ Examples:
 		if err != nil {
 			return err
 		}
+
+		// Validate: --network requires --project-name
+		if network != "" && projectName == "" {
+			return fmt.Errorf("--project-name is required when using --network")
+		}
+
+		// Default project name to gateway name if not provided
+		if projectName == "" {
+			projectName = name
+		}
+
 		noColor, err := cmd.Flags().GetBool("no-color")
 		if err != nil {
 			return err
@@ -43,9 +56,10 @@ Examples:
 			Name:           name,
 			Backends:       zosBackends,
 			TLSPassthrough: tls,
-			SolutionType:   name,
+			SolutionType:   projectName, // Use project name
 			FQDN:           fqdn,
 			NodeID:         node,
+			Network:        network,
 		}
 		cfg, err := config.GetUserConfig()
 		if err != nil {

--- a/grid-cli/cmd/deploy_gateway_name.go
+++ b/grid-cli/cmd/deploy_gateway_name.go
@@ -2,6 +2,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	command "github.com/threefoldtech/grid-agent/grid-cli/internal/cmd"
@@ -21,17 +23,29 @@ Creates a subdomain on a gateway node that proxies to your backend.
 
 Examples:
   # Deploy gateway with backend
-  tfcmd deploy gateway name --name myapp --backends http://10.20.2.2:8000`,
+  tfcmd deploy gateway name --name myapp --node 11 --backends http://10.20.2.2:8080`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		name, tls, zosBackends, node, err := parseCommonGatewayFlags(cmd)
+		name, tls, zosBackends, node, network, projectName, err := parseCommonGatewayFlags(cmd)
 		if err != nil {
 			return err
 		}
+
+		// Validate: --network requires --project-name
+		if network != "" && projectName == "" {
+			return fmt.Errorf("--project-name is required when using --network")
+		}
+
+		// Default project name to gateway name if not provided
+		if projectName == "" {
+			projectName = name
+		}
+
 		gateway := workloads.GatewayNameProxy{
 			Name:           name,
 			Backends:       zosBackends,
 			TLSPassthrough: tls,
-			SolutionType:   name,
+			SolutionType:   projectName, // Use project name
+			Network:        network,
 		}
 		farm, err := cmd.Flags().GetUint64("farm")
 		if err != nil {
@@ -96,6 +110,6 @@ func init() {
 	deployGatewayCmd.AddCommand(deployGatewayNameCmd)
 
 	deployGatewayNameCmd.Flags().Uint32("node", 0, "node id gateway should be deployed on")
-	deployGatewayNameCmd.Flags().Uint64("farm", 1, "farm id gateway should be deployed on")
+	deployGatewayNameCmd.Flags().Uint64("farm", 0, "farm ID for deployment (0 = any farm, or specify farm ID)")
 	deployGatewayNameCmd.MarkFlagsMutuallyExclusive("node", "farm")
 }

--- a/grid-cli/cmd/deploy_gateway_name.go
+++ b/grid-cli/cmd/deploy_gateway_name.go
@@ -21,9 +21,25 @@ var deployGatewayNameCmd = &cobra.Command{
 
 Creates a subdomain on a gateway node that proxies to your backend.
 
+To avoid name collisions, you can follow this convention to creates unique subdomain: solution prefix + twin ID + a chosen name. (e.g., wp41myapp)
+
+IMPORTANT: Gateway must be able to reach your backend. Choose ONE option:
+
+- SAME NETWORK: Deploy gateway and VM on same network
+   tfcmd deploy vm --name webapp --project-name myapp --ssh ~/.ssh/id_rsa.pub
+   tfcmd deploy gateway name --name api --node 11 --backends http://10.20.2.2:8080 --network myappnetwork --project-name myapp
+
+- SAME NODE: Deploy gateway and VM on same node
+   tfcmd deploy vm --name webapp --node 11 --ssh ~/.ssh/id_rsa.pub
+   tfcmd deploy gateway name --name api --node 11 --backends http://10.20.2.2:8080
+
+- PUBLIC IP: Use VM's public IP, planetary or mycelium IP as backend
+   tfcmd deploy vm --name webapp --ipv4 --ssh ~/.ssh/id_rsa.pub
+   tfcmd deploy gateway name --name api --node 11 --backends http://<VM-PUBLIC-IP>:8080
+
 Examples:
-  # Deploy gateway with backend
-  tfcmd deploy gateway name --name myapp --node 11 --backends http://10.20.2.2:8080`,
+  # Option 1: Same network (recommended for multi-VM)
+  tfcmd deploy gateway name --name myapp --node 11 --backends http://10.20.2.2:8080 --network myappnetwork --project-name myapp`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name, tls, zosBackends, node, network, projectName, err := parseCommonGatewayFlags(cmd)
 		if err != nil {

--- a/grid-cli/cmd/deploy_vm.go
+++ b/grid-cli/cmd/deploy_vm.go
@@ -104,16 +104,12 @@ Use --project-name to organize VMs into projects and --network to deploy
 multiple VMs on the same network.
 
 **Disks vs Volumes**:
-- Disks: Local SSD storage on the node (faster, not shared between VMs)
-- Volumes: Distributed QSFS storage (slower, can be shared across VMs)
+- Disks (zmount): Legacy sparse files on host filesystem (slower, being deprecated)
+- Volumes: Modern btrfs subvolumes with quota (faster, future of storage)
 
-Use disks for: databases, caches, temporary files
-Use volumes for: shared data, backups, large files
+Key advantages of volumes: better performance, snapshots, live resize, better caching
+Recommendation: Use volumes for all new deployments, disks only for backward compatibility
 
-**Network Limitations**:
-IMPORTANT: Networks can only span nodes within the same farm. Nodes in different
-farms cannot share a network. For cross-farm deployments, use separate networks
-or planetary network IPs for inter-VM communication.
 
 Examples:
   # Deploy single VM with default settings
@@ -140,7 +136,7 @@ Examples:
 		}
 		sshKey, err := os.ReadFile(sshFile)
 		if err != nil {
-			log.Fatal().Err(err).Send()
+			return fmt.Errorf("failed to read SSH key file '%s': %w", sshFile, err)
 		}
 		env["SSH_KEY"] = string(sshKey)
 		node, err := cmd.Flags().GetUint32("node")
@@ -194,9 +190,6 @@ Examples:
 		if err != nil {
 			return err
 		}
-		if len(gpus) > 0 && node == 0 {
-			log.Fatal().Msg("must specify node ID when using GPUs")
-		}
 
 		ipv4, err := cmd.Flags().GetBool("ipv4")
 		if err != nil {
@@ -227,7 +220,7 @@ Examples:
 		if mycelium {
 			seed, err = workloads.RandomMyceliumIPSeed()
 			if err != nil {
-				log.Fatal().Err(err).Send()
+				return fmt.Errorf("failed to generate mycelium IP seed: %w", err)
 			}
 		}
 
@@ -263,7 +256,7 @@ Examples:
 
 		cfg, err := config.GetUserConfig()
 		if err != nil {
-			log.Fatal().Err(err).Send()
+			return fmt.Errorf("failed to get user config: %w", err)
 		}
 
 		opts := []deployer.PluginOpt{
@@ -279,7 +272,7 @@ Examples:
 		}
 		t, err := deployer.NewTFPluginClient(cfg.Mnemonics, opts...)
 		if err != nil {
-			log.Fatal().Err(err).Send()
+			return fmt.Errorf("failed to create TFPluginClient: %w", err)
 		}
 
 		// if no public ips or yggdrasil then we should go for the light deployment
@@ -288,7 +281,7 @@ Examples:
 		if node != 0 {
 			isLight, err = isZos4Node(cmd.Context(), t.NcPool, t.SubstrateConn, node)
 			if err != nil {
-				log.Fatal().Err(err).Send()
+				return fmt.Errorf("failed to check if node %d supports light VMs: %w", node, err)
 			}
 		}
 

--- a/grid-cli/cmd/deploy_vm.go
+++ b/grid-cli/cmd/deploy_vm.go
@@ -103,14 +103,26 @@ Supports single VM deployment or multi-VM deployments with shared networks.
 Use --project-name to organize VMs into projects and --network to deploy
 multiple VMs on the same network.
 
+**Disks vs Volumes**:
+- Disks: Local SSD storage on the node (faster, not shared between VMs)
+- Volumes: Distributed QSFS storage (slower, can be shared across VMs)
+
+Use disks for: databases, caches, temporary files
+Use volumes for: shared data, backups, large files
+
+**Network Limitations**:
+IMPORTANT: Networks can only span nodes within the same farm. Nodes in different
+farms cannot share a network. For cross-farm deployments, use separate networks
+or planetary network IPs for inter-VM communication.
+
 Examples:
   # Deploy single VM with default settings
   tfcmd deploy vm --name myvm --ssh ~/.ssh/id_rsa.pub
   
-  # Deploy VM with custom project name
+  # Deploy VM with custom resources and project name
   tfcmd deploy vm --name webserver --ssh ~/.ssh/id_rsa.pub --cpu 4 --memory 8 --project-name production
   
-  # Deploy multiple VMs on shared network
+  # Deploy multiple VMs on shared network (same farm)
   tfcmd deploy vm --name vm01 --ssh ~/.ssh/id_rsa.pub --project-name myapp
   tfcmd deploy vm --name vm02 --ssh ~/.ssh/id_rsa.pub --network myappnetwork --project-name myapp`,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -229,6 +241,16 @@ Examples:
 			return err
 		}
 
+		// Validate: --node and --farm are mutually exclusive
+		if node != 0 && farm != 0 {
+			return fmt.Errorf("--node and --farm flags are mutually exclusive")
+		}
+
+		// Validate: --gpus requires --node
+		if len(gpus) > 0 && node == 0 {
+			return fmt.Errorf("--gpus requires --node flag to specify which node has the GPU")
+		}
+
 		// Validate: --network requires --project-name
 		if networkName != "" && projectName == "" {
 			return fmt.Errorf("--project-name is required when using --network")
@@ -323,7 +345,7 @@ func init() {
 	if err != nil {
 		log.Fatal().Err(err).Send()
 	}
-	deployVMCmd.Flags().String("ssh", "", "path to public ssh key")
+	deployVMCmd.Flags().StringP("ssh", "s", "", "path to public SSH key file (e.g., ~/.ssh/id_rsa.pub)")
 	// should it be required?
 	err = deployVMCmd.MarkFlagRequired("ssh")
 	if err != nil {
@@ -331,13 +353,13 @@ func init() {
 	}
 
 	deployVMCmd.Flags().Uint32("node", 0, "node id vm should be deployed on")
-	deployVMCmd.Flags().Uint64("farm", 1, "farm id vm should be deployed on")
+	deployVMCmd.Flags().Uint64("farm", 0, "farm ID for deployment (0 = any farm, or specify farm ID)")
 	deployVMCmd.MarkFlagsMutuallyExclusive("node", "farm")
 	deployVMCmd.Flags().String("network", "", "name of existing network to deploy VM on. If not specified, a new network will be created default to '{vmname}network'")
 	deployVMCmd.Flags().String("project-name", "", "project name for the VM deployment. Defaults to 'vm/{vmname}' if not specified. Required when using --network")
 
 	deployVMCmd.Flags().Uint8("cpu", 1, "number of cpu units")
-	deployVMCmd.Flags().Uint64("memory", 1, "memory size in gb")
+	deployVMCmd.Flags().Uint64("memory", 1, "memory size in GB (e.g., --memory 2 for 2GB RAM)")
 	deployVMCmd.Flags().Uint64("rootfs", 2, "root filesystem size in gb")
 	deployVMCmd.Flags().StringSlice("disk", []string{}, "disk specification in format 'size:mountpoint' (e.g., '10:/data'). Can be specified multiple times. For backward compatibility, just 'size' defaults to '/data'")
 	deployVMCmd.Flags().String("flist", ubuntuFlist, "flist for vm")
@@ -350,7 +372,7 @@ func init() {
 
 	deployVMCmd.Flags().Bool("ipv4", false, "assign public ipv4 for vm")
 	deployVMCmd.Flags().Bool("ipv6", false, "assign public ipv6 for vm")
-	deployVMCmd.Flags().Bool("ygg", false, "assign yggdrasil ip for vm")
+	deployVMCmd.Flags().Bool("ygg", true, "assign planetary network IP (Yggdrasil) for VM")
 	deployVMCmd.Flags().Bool("mycelium", true, "assign mycelium ip for vm")
 	deployVMCmd.Flags().StringToStringP("env", "e", make(map[string]string), "environment variables for the vm")
 }

--- a/grid-cli/cmd/deploy_zdb.go
+++ b/grid-cli/cmd/deploy_zdb.go
@@ -194,6 +194,6 @@ func init() {
 	deployZDBCmd.Flags().Bool("public", false, "if zdb gets a public ip6")
 
 	deployZDBCmd.Flags().Uint32("node", 0, "node id that zdb should be deployed on")
-	deployZDBCmd.Flags().Uint64("farm", 1, "farm id that zdb should be deployed on")
+	deployZDBCmd.Flags().Uint64("farm", 0, "farm ID for deployment (0 = any farm, or specify farm ID)")
 	deployZDBCmd.MarkFlagsMutuallyExclusive("node", "farm")
 }

--- a/grid-cli/cmd/list.go
+++ b/grid-cli/cmd/list.go
@@ -1,0 +1,16 @@
+// Package cmd for parsing command line arguments
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// listCmd represents the list command
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List available resources on Threefold grid",
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+}

--- a/grid-cli/cmd/list_gateways.go
+++ b/grid-cli/cmd/list_gateways.go
@@ -1,0 +1,23 @@
+// Package cmd for parsing command line arguments
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// listGatewaysCmd represents the list gateways command
+var listGatewaysCmd = &cobra.Command{
+	Use:   "gateways",
+	Short: "List available gateway nodes",
+	Long: `List available gateway nodes on the ThreeFold Grid.
+
+Gateway nodes provide domains or public IPs for exposing your workloads.
+
+Available Commands:
+  name        List gateways with domains (for name proxy)
+  fqdn        List gateways with public IPs (for FQDN proxy)`,
+}
+
+func init() {
+	listCmd.AddCommand(listGatewaysCmd)
+}

--- a/grid-cli/cmd/list_gateways_fqdn.go
+++ b/grid-cli/cmd/list_gateways_fqdn.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/threefoldtech/grid-agent/grid-cli/internal/config"
+	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/deployer"
+	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
+)
+
+// listGatewaysFQDNCmd represents the list gateways fqdn command
+var listGatewaysFQDNCmd = &cobra.Command{
+	Use:   "fqdn",
+	Short: "List gateways with public IPs",
+	Long: `List gateway nodes with public IP addresses for FQDN Gateway deployments.
+
+Shows node IDs and public IPs you need for deploying FQDN Gateways.
+You'll point your custom domain's DNS to these IPs.
+
+Examples:
+  # List all FQDN gateways
+  tfcmd list gateways fqdn
+  
+  # Filter by country
+  tfcmd list gateways fqdn --country Germany
+  
+  # Filter by farm
+  tfcmd list gateways fqdn --farm 2`,
+	Run: func(cmd *cobra.Command, args []string) {
+		farmID, err := cmd.Flags().GetUint64("farm")
+		if err != nil {
+			log.Fatal().Err(err).Send()
+		}
+
+		country, err := cmd.Flags().GetString("country")
+		if err != nil {
+			log.Fatal().Err(err).Send()
+		}
+
+		disableSentry, err := cmd.Flags().GetBool("disable-sentry")
+		if err != nil {
+			log.Fatal().Err(err).Send()
+		}
+
+		cfg, err := config.GetUserConfig()
+		if err != nil {
+			log.Fatal().Err(err).Send()
+		}
+
+		opts := []deployer.PluginOpt{
+			deployer.WithNetwork(cfg.Network),
+			deployer.WithRMBTimeout(100),
+		}
+
+		if disableSentry {
+			opts = append(opts, deployer.WithDisableSentry())
+		}
+
+		t, err := deployer.NewTFPluginClient(cfg.Mnemonics, opts...)
+		if err != nil {
+			log.Fatal().Err(err).Send()
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		err = listGatewaysFQDN(ctx, t, farmID, country, cmd.OutOrStdout())
+		if err != nil {
+			log.Fatal().Err(err).Send()
+		}
+	},
+}
+
+func init() {
+	listGatewaysCmd.AddCommand(listGatewaysFQDNCmd)
+
+	listGatewaysFQDNCmd.Flags().Uint64("farm", 0, "filter by farm ID")
+	listGatewaysFQDNCmd.Flags().String("country", "", "filter by country")
+}
+
+func listGatewaysFQDN(ctx context.Context, t deployer.TFPluginClient, farmID uint64, country string, writer io.Writer) error {
+	// Build filter for nodes with public IPs (no domain requirement)
+	farmIDs := []uint64{}
+	if farmID > 0 {
+		farmIDs = []uint64{farmID}
+	}
+
+	rented := false
+	freeIPs := uint64(1) // Require at least 1 public IP
+
+	filter := types.NodeFilter{
+		Status:  []string{"up"},
+		FarmIDs: farmIDs,
+		FreeIPs: &freeIPs,
+		Rented:  &rented,
+	}
+
+	// Query nodes
+	nodes, err := deployer.FilterNodes(ctx, t, filter, nil, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to query gateway nodes: %w", err)
+	}
+
+	// Filter by country if specified
+	if country != "" {
+		var filtered []types.Node
+		for _, node := range nodes {
+			if strings.EqualFold(node.Location.Country, country) {
+				filtered = append(filtered, node)
+			}
+		}
+		nodes = filtered
+	}
+
+	// Filter nodes with public IPs
+	var gatewaysWithPublicIPs []types.Node
+	for _, node := range nodes {
+		if node.PublicConfig.Ipv4 != "" || node.PublicConfig.Ipv6 != "" {
+			gatewaysWithPublicIPs = append(gatewaysWithPublicIPs, node)
+		}
+	}
+
+	if len(gatewaysWithPublicIPs) == 0 {
+		log.Info().Msg("No gateway nodes with public IPs found")
+		return nil
+	}
+
+	printFQDNGatewayTable(gatewaysWithPublicIPs, writer)
+	return nil
+}
+
+func printFQDNGatewayTable(nodes []types.Node, writer io.Writer) {
+	table := tabwriter.NewWriter(writer, 0, 0, 4, ' ', 0)
+	fmt.Fprintln(table, "Node ID\tPublic IPv4\tPublic IPv6\tFarm ID\tCountry\tCity")
+
+	for _, node := range nodes {
+		ipv4 := node.PublicConfig.Ipv4
+		if ipv4 == "" {
+			ipv4 = "-"
+		}
+
+		ipv6 := node.PublicConfig.Ipv6
+		if ipv6 == "" {
+			ipv6 = "-"
+		}
+
+		fmt.Fprintf(table, "%d\t%s\t%s\t%d\t%s\t%s\n",
+			node.NodeID,
+			ipv4,
+			ipv6,
+			node.FarmID,
+			node.Location.Country,
+			node.Location.City,
+		)
+	}
+
+	table.Flush()
+}

--- a/grid-cli/cmd/list_gateways_name.go
+++ b/grid-cli/cmd/list_gateways_name.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/threefoldtech/grid-agent/grid-cli/internal/config"
+	"github.com/threefoldtech/grid-agent/grid-cli/internal/filters"
+	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/deployer"
+	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
+)
+
+// listGatewaysNameCmd represents the list gateways name command
+var listGatewaysNameCmd = &cobra.Command{
+	Use:   "name",
+	Short: "List gateways with domains",
+	Long: `List gateway nodes with configured domains for Name Gateway deployments.
+
+Shows available domains you'll get when deploying a Name Gateway.
+
+Examples:
+  # List all name gateways
+  tfcmd list gateways name
+  
+  # Filter by country
+  tfcmd list gateways name --country Belgium
+  
+  # Filter by farm
+  tfcmd list gateways name --farm 1`,
+	Run: func(cmd *cobra.Command, args []string) {
+		farmID, err := cmd.Flags().GetUint64("farm")
+		if err != nil {
+			log.Fatal().Err(err).Send()
+		}
+
+		country, err := cmd.Flags().GetString("country")
+		if err != nil {
+			log.Fatal().Err(err).Send()
+		}
+
+		disableSentry, err := cmd.Flags().GetBool("disable-sentry")
+		if err != nil {
+			log.Fatal().Err(err).Send()
+		}
+
+		cfg, err := config.GetUserConfig()
+		if err != nil {
+			log.Fatal().Err(err).Send()
+		}
+
+		opts := []deployer.PluginOpt{
+			deployer.WithNetwork(cfg.Network),
+			deployer.WithRMBTimeout(100),
+		}
+
+		if disableSentry {
+			opts = append(opts, deployer.WithDisableSentry())
+		}
+
+		t, err := deployer.NewTFPluginClient(cfg.Mnemonics, opts...)
+		if err != nil {
+			log.Fatal().Err(err).Send()
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		err = listGatewaysName(ctx, t, farmID, country, cmd.OutOrStdout())
+		if err != nil {
+			log.Fatal().Err(err).Send()
+		}
+	},
+}
+
+func init() {
+	listGatewaysCmd.AddCommand(listGatewaysNameCmd)
+
+	listGatewaysNameCmd.Flags().Uint64("farm", 0, "filter by farm ID")
+	listGatewaysNameCmd.Flags().String("country", "", "filter by country")
+}
+
+func listGatewaysName(ctx context.Context, t deployer.TFPluginClient, farmID uint64, country string, writer io.Writer) error {
+	// Build filter for gateways with domains
+	filter := filters.BuildGatewayFilter(farmID)
+
+	// Query nodes
+	nodes, err := deployer.FilterNodes(ctx, t, filter, nil, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to query gateway nodes: %w", err)
+	}
+
+	// Filter by country if specified
+	if country != "" {
+		var filtered []types.Node
+		for _, node := range nodes {
+			if strings.EqualFold(node.Location.Country, country) {
+				filtered = append(filtered, node)
+			}
+		}
+		nodes = filtered
+	}
+
+	// Filter nodes with domains
+	var gatewaysWithDomains []types.Node
+	for _, node := range nodes {
+		if node.PublicConfig.Domain != "" {
+			gatewaysWithDomains = append(gatewaysWithDomains, node)
+		}
+	}
+
+	if len(gatewaysWithDomains) == 0 {
+		log.Info().Msg("No gateway nodes with domains found")
+		return nil
+	}
+
+	printNameGatewayTable(gatewaysWithDomains, writer)
+	return nil
+}
+
+func printNameGatewayTable(nodes []types.Node, writer io.Writer) {
+	table := tabwriter.NewWriter(writer, 0, 0, 4, ' ', 0)
+	fmt.Fprintln(table, "Node ID\tDomain\tFarm ID\tCountry\tCity")
+
+	for _, node := range nodes {
+		fmt.Fprintf(table, "%d\t%s\t%d\t%s\t%s\n",
+			node.NodeID,
+			node.PublicConfig.Domain,
+			node.FarmID,
+			node.Location.Country,
+			node.Location.City,
+		)
+	}
+
+	table.Flush()
+}

--- a/grid-cli/cmd/root.go
+++ b/grid-cli/cmd/root.go
@@ -32,5 +32,5 @@ func GetRootCmd() *cobra.Command {
 func init() {
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
-	rootCmd.PersistentFlags().Bool("disable-sentry", false, "disable sentry")
+	rootCmd.PersistentFlags().Bool("disable-sentry", true, "disable sentry")
 }

--- a/grid-cli/docs/cancel.md
+++ b/grid-cli/docs/cancel.md
@@ -1,0 +1,127 @@
+# Cancel Commands
+
+Cancel resources on the ThreeFold Grid by project name or contract ID.
+
+## Cancel Project
+
+Cancel entire projects or specific VMs within multi-VM projects.
+
+### Cancel Entire Project
+
+```bash
+tfcmd cancel --project-name <project-name>
+```
+
+**Required Flags:**
+- `--project-name`: Project name to cancel
+
+This cancels all resources in the project (all VMs, gateways, and the network).
+
+**Example:**
+```console
+$ tfcmd cancel --project-name vm/examplevm
+3:37PM INF canceling project 'vm/examplevm'
+3:37PM INF successfully canceled project 'vm/examplevm'
+```
+
+### Cancel Specific VM (Granular Cancellation)
+
+```bash
+tfcmd cancel --project-name <project-name> --vm <vm-name>
+```
+
+**Required Flags:**
+- `--project-name`: Project name containing the VM
+
+**Optional Flags:**
+- `--vm`: Specific VM name to cancel (if not specified, cancels entire project)
+
+This removes a specific VM from a multi-VM project while keeping other VMs running. The network is automatically updated to remove the canceled VM's node.
+
+**Example:**
+```console
+# Cancel vm02 from multi-VM project, keep vm01 and vm03 running
+$ tfcmd cancel --project-name myapp --vm vm02
+3:40PM INF canceling VM 'vm02' from project 'myapp'
+3:40PM INF successfully canceled VM 'vm02'
+```
+
+## Cancel Contracts
+
+Cancel twin contracts directly by contract ID.
+
+```bash
+tfcmd cancel contracts [flags]
+```
+
+**Required Flags:**
+- `--contract-id`: Contract ID to cancel
+
+**Example:**
+```console
+$ tfcmd cancel contracts --contract-id 123456
+3:45PM INF canceling contract 123456
+3:45PM INF successfully canceled contract 123456
+```
+
+## Finding Project Names
+
+To find your existing project names, use:
+```bash
+tfcmd get contracts
+```
+
+For VMs deployed with default project names, use `vm/{vmname}`:
+```bash
+# Old command
+tfcmd get vm myvm
+
+# New command  
+tfcmd get vm myvm --project-name vm/myvm
+```
+
+## Network Behavior
+
+When canceling VMs from multi-VM projects:
+- ✅ The network is automatically updated
+- ✅ The canceled VM's node is removed from the network
+- ✅ Other VMs in the project continue running
+- ✅ Network routes are recalculated
+
+## Use Cases
+
+### Development Cleanup
+```bash
+# Cancel entire development environment
+tfcmd cancel --project-name dev/myapp
+```
+
+### Production Maintenance
+```bash
+# Remove specific faulty VM while keeping others running
+tfcmd cancel --project-name production/webapp --vm web03
+```
+
+### Contract Management
+```bash
+# Cancel specific contract by ID
+tfcmd cancel contracts --contract-id 987654
+```
+
+## Error Handling
+
+**Common errors and solutions:**
+
+- **Project not found**: Check project name with `tfcmd get contracts`
+- **VM not in project**: Verify VM name exists in the project
+- **Contract already canceled**: Contract may already be canceled
+- **Permission denied**: Ensure you own the contract/project
+
+## Breaking Changes
+
+> **Warning**: The cancel command now requires the `--project-name` flag:
+
+- Old: `tfcmd cancel <name>`  
+- New: `tfcmd cancel --project-name <project>`
+
+See the migration guide in the VM documentation for details.

--- a/grid-cli/docs/gateway-fqdn.md
+++ b/grid-cli/docs/gateway-fqdn.md
@@ -17,7 +17,11 @@ tfcmd deploy gateway fqdn [flags]
 
 ### Optional Flags
 
--tls: add TLS passthrough option (default false).
+- tls: add TLS passthrough option (default false).
+- network: network name (optional, for reference). Required when backend uses private IP.
+- project-name: project name for grouping deployments (required when using --network).
+
+See [Gateway Name documentation](gateway-name.md#network-flag-usage) for network flag usage examples.
 
 Example:
 

--- a/grid-cli/docs/gateway-fqdn.md
+++ b/grid-cli/docs/gateway-fqdn.md
@@ -21,7 +21,73 @@ tfcmd deploy gateway fqdn [flags]
 - network: network name (optional, for reference). Required when backend uses private IP.
 - project-name: project name for grouping deployments (required when using --network).
 
-See [Gateway Name documentation](gateway-name.md#network-flag-usage) for network flag usage examples.
+### Network Flag Usage
+
+The `--network` flag is optional but important for gateway-backend connectivity:
+
+**IMPORTANT: Gateway must be able to reach your backend. Choose ONE option:**
+
+#### 1️⃣ SAME NETWORK (Recommended for multi-VM)
+Deploy gateway and VM on the same network using private IPs:
+
+```bash
+# Deploy VM first
+tfcmd deploy vm --name webapp --project-name myapp --ssh ~/.ssh/id_rsa.pub
+
+# Deploy gateway on same network
+tfcmd deploy gateway fqdn --name api --fqdn api.example.com --node 11 \
+  --backends http://10.20.2.2:8080 \
+  --network myappnetwork \
+  --project-name myapp
+```
+
+#### 2️⃣ SAME NODE (Simplest option)
+Deploy gateway and VM on the same node:
+
+```bash
+# Deploy VM on specific node
+tfcmd deploy vm --name webapp --node 11 --ssh ~/.ssh/id_rsa.pub
+
+# Deploy gateway on same node
+tfcmd deploy gateway fqdn --name api --fqdn api.example.com --node 11 \
+  --backends http://10.20.2.2:8080
+```
+
+#### 3️⃣ PUBLIC IP (Cross-farm deployment)
+Use VM's public IP as backend:
+
+```bash
+# Deploy VM with public IP
+tfcmd deploy vm --name webapp --ipv4 --ssh ~/.ssh/id_rsa.pub
+
+# Deploy gateway using VM's public IP
+tfcmd deploy gateway fqdn --name api --fqdn api.example.com --node 11 \
+  --backends http://203.0.113.1:8080
+```
+
+#### 4️⃣ PLANETARY/MYCELIUM IP (Cross-network)
+Use planetary or mycelium IP as backend:
+
+```bash
+# Deploy VM (get planetary IP from get vm output)
+tfcmd deploy vm --name webapp --ssh ~/.ssh/id_rsa.pub
+tfcmd get vm webapp --project-name vm/webapp  # Note planetary IP
+
+# Deploy gateway using planetary IP
+tfcmd deploy gateway fqdn --name api --fqdn api.example.com --node 11 \
+  --backends http://302:9e63:7d43:b742:c2e0:ab69:e101:8032:8080
+```
+
+**Network Flag Requirements:**
+- **Required** when backend uses private IP (10.x.x.x from same network)
+- **Optional** when backend uses public, planetary, or mycelium IP
+- **Must match** the VM's project name when using `--network`
+
+**DNS Configuration:**
+After deployment, configure your DNS:
+```
+api.example.com → <gateway-node-public-IP>
+```
 
 Example:
 

--- a/grid-cli/docs/gateway-name.md
+++ b/grid-cli/docs/gateway-name.md
@@ -17,7 +17,29 @@ tfcmd deploy gateway name [flags]
 
 - node: node id gateway should be deployed on.
 - farm: farm id gateway should be deployed on, if set choose available node from farm that fits vm specs (default 1). note: node and farm flags cannot be set both.
--tls: add TLS passthrough option (default false).
+- tls: add TLS passthrough option (default false).
+- network: network name (optional, for reference). Required when backend uses private IP.
+- project-name: project name for grouping deployments (required when using --network).
+
+### Network Flag Usage
+
+The `--network` flag is optional but important:
+- **Required** when backend uses private IP (10.x.x.x from WireGuard network)
+- **Optional** when backend uses public or planetary IP
+
+**Example with private IP backend**:
+```bash
+tfcmd deploy gateway name --name mygw --node 11 \
+  --backends http://10.20.2.2:8080 \
+  --network myvmnetwork \
+  --project-name myapp
+```
+
+**Example with public IP backend**:
+```bash
+tfcmd deploy gateway name --name mygw --node 11 \
+  --backends http://203.0.113.1:8080
+```
 
 Example:
 

--- a/grid-cli/docs/gateway-name.md
+++ b/grid-cli/docs/gateway-name.md
@@ -23,23 +23,65 @@ tfcmd deploy gateway name [flags]
 
 ### Network Flag Usage
 
-The `--network` flag is optional but important:
-- **Required** when backend uses private IP (10.x.x.x from WireGuard network)
-- **Optional** when backend uses public or planetary IP
+The `--network` flag is optional but important for gateway-backend connectivity:
 
-**Example with private IP backend**:
+**IMPORTANT: Gateway must be able to reach your backend. Choose ONE option:**
+
+#### 1️⃣ SAME NETWORK (Recommended for multi-VM)
+Deploy gateway and VM on the same network using private IPs:
+
 ```bash
-tfcmd deploy gateway name --name mygw --node 11 \
+# Deploy VM first
+tfcmd deploy vm --name webapp --project-name myapp --ssh ~/.ssh/id_rsa.pub
+
+# Deploy gateway on same network
+tfcmd deploy gateway name --name api --node 11 \
   --backends http://10.20.2.2:8080 \
-  --network myvmnetwork \
+  --network myappnetwork \
   --project-name myapp
 ```
 
-**Example with public IP backend**:
+#### 2️⃣ SAME NODE (Simplest option)
+Deploy gateway and VM on the same node:
+
 ```bash
-tfcmd deploy gateway name --name mygw --node 11 \
+# Deploy VM on specific node
+tfcmd deploy vm --name webapp --node 11 --ssh ~/.ssh/id_rsa.pub
+
+# Deploy gateway on same node
+tfcmd deploy gateway name --name api --node 11 \
+  --backends http://10.20.2.2:8080
+```
+
+#### 3️⃣ PUBLIC IP (Cross-farm deployment)
+Use VM's public IP as backend:
+
+```bash
+# Deploy VM with public IP
+tfcmd deploy vm --name webapp --ipv4 --ssh ~/.ssh/id_rsa.pub
+
+# Deploy gateway using VM's public IP
+tfcmd deploy gateway name --name api --node 11 \
   --backends http://203.0.113.1:8080
 ```
+
+#### 4️⃣ PLANETARY/MYCELIUM IP (Cross-network)
+Use planetary or mycelium IP as backend:
+
+```bash
+# Deploy VM (get planetary IP from get vm output)
+tfcmd deploy vm --name webapp --ssh ~/.ssh/id_rsa.pub
+tfcmd get vm webapp --project-name vm/webapp  # Note planetary IP
+
+# Deploy gateway using planetary IP
+tfcmd deploy gateway name --name api --node 11 \
+  --backends http://302:9e63:7d43:b742:c2e0:ab69:e101:8032:8080
+```
+
+**Network Flag Requirements:**
+- **Required** when backend uses private IP (10.x.x.x from same network)
+- **Optional** when backend uses public, planetary, or mycelium IP
+- **Must match** the VM's project name when using `--network`
 
 Example:
 

--- a/grid-cli/docs/get.md
+++ b/grid-cli/docs/get.md
@@ -1,0 +1,299 @@
+# Get Commands
+
+Retrieve information about deployed resources on the ThreeFold Grid.
+
+## Get VM
+
+Retrieve detailed information about a deployed virtual machine.
+
+```bash
+tfcmd get vm <vm-name> --project-name <project-name>
+```
+
+**Required Flags:**
+- `--project-name`: Project name of the VM deployment
+
+**Arguments:**
+- `vm-name`: Name of the VM used during deployment
+
+**Example:**
+```console
+$ tfcmd get vm examplevm --project-name vm/examplevm
+11:56AM INF starting peer session=tf-1522837 twin=192
+11:56AM INF vm:
+{
+        "Name": "examplevm",
+        "NodeID": 11,
+        "SolutionType": "vm/examplevm",
+        "SolutionProvider": null,
+        "NetworkName": "examplevmnetwork",
+        "Disks": [
+                {
+                        "name": "examplevmdisk",
+                        "size": 10,
+                        "description": ""
+                }
+        ],
+        "Zdbs": [],
+        "Vms": [
+                {
+                        "name": "examplevm",
+                        "flist": "https://hub.grid.tf/tf-official-apps/threefoldtech-ubuntu-22.04.flist",
+                        "flist_checksum": "",
+                        "publicip": false,
+                        "publicip6": false,
+                        "planetary": true,
+                        "corex": false,
+                        "computedip": "",
+                        "computedip6": "",
+                        "planetary_ip": "302:9e63:7d43:b742:c2e0:ab69:e101:8032",
+                        "mycelium_ip": "45f:6cd6:8c6d:6c73:ff0f:6c97:11e3:4e84",
+                        "ip": "10.20.2.2",
+                        "mycelium_ip_seed": "bJcR406E",
+                        "description": "",
+                        "gpus": null,
+                        "cpu": 2,
+                        "memory": 4096,
+                        "rootfs_size": 2048,
+                        "entrypoint": "/sbin/zinit init",
+                        "mounts": [
+                                {
+                                        "disk_name": "examplevmdisk",
+                                        "mount_point": "/data"
+                                }
+                        ],
+                        "zlogs": null,
+                        "env_vars": {
+                                "SSH_KEY": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDcGrS1RT36rHAGLK3/4FMazGXjIYgWVnZ4bCvxxg8KosEEbs/DeUKT2T2LYV91jUq3yibTWwK0nc6O+K5kdShV4qsQlPmIbdur6x2zWHPeaGXqejbbACEJcQMCj8szSbG8aKwH8Nbi8BNytgzJ20Ysaaj2QpjObCZ4Ncp+89pFahzDEIJx2HjXe6njbp6eCduoA+IE2H9vgwbIDVMQz6y/TzjdQjgbMOJRTlP+CzfbDBb6Ux+ed8F184bMPwkFrpHs9MSfQVbqfIz8wuq/wjewcnb3wK9dmIot6CxV2f2xuOZHgNQmVGratK8TyBnOd5x4oZKLIh3qM9Bi7r81xCkXyxAZbWYu3gGdvo3h85zeCPGK8OEPdYWMmIAIiANE42xPmY9HslPz8PAYq6v0WwdkBlDWrG3DD3GX6qTt9lbSHEgpUP2UOnqGL4O1+g5Rm9x16HWefZWMjJsP6OV70PnMjo9MPnH+yrBkXISw4CGEEXryTvupfaO5sL01mn+UOyE= user@host\n"
+                        },
+                        "network_name": "examplevmnetwork",
+                        "console_url": "10.20.2.0:20002"
+                }
+        ],
+        "QSFS": [],
+        "NodeDeploymentID": {
+                "11": 100063
+        },
+        "ContractID": 100063,
+        "IPrange": "10.20.2.0/24"
+}
+```
+
+## Get Gateway
+
+Retrieve information about deployed gateway proxies.
+
+### Get Gateway Name
+
+```bash
+tfcmd get gateway name <gateway-name> --project-name <project-name>
+```
+
+**Example:**
+```console
+$ tfcmd get gateway name mygateway --project-name myapp
+12:15PM INF starting peer session=tf-1522840 twin=192
+12:15PM INF gateway name:
+{
+        "Name": "mygateway",
+        "NodeID": 14,
+        "SolutionType": "gateway.name/myapp",
+        "NetworkName": "myappnetwork",
+        "Gateways": [
+                {
+                        "name": "mygateway",
+                        "node_id": 14,
+                        "tls_passthrough": false,
+                        "backends": ["http://10.20.2.2:8080"],
+                        "fqdn": "mygateway.gent01.dev.grid.tf"
+                }
+        ]
+}
+```
+
+### Get Gateway FQDN
+
+```bash
+tfcmd get gateway fqdn <gateway-name> --project-name <project-name>
+```
+
+**Example:**
+```console
+$ tfcmd get gateway fqdn myapp --project-name myapp
+12:20PM INF starting peer session=tf-1522841 twin=192
+12:20PM INF gateway fqdn:
+{
+        "Name": "myapp",
+        "NodeID": 14,
+        "SolutionType": "gateway.fqdn/myapp",
+        "Gateways": [
+                {
+                        "name": "myapp",
+                        "node_id": 14,
+                        "fqdn": "myapp.com",
+                        "backends": ["http://10.20.2.2:8080"]
+                }
+        ]
+}
+```
+
+## Get Kubernetes
+
+Retrieve information about deployed Kubernetes clusters.
+
+```bash
+tfcmd get kubernetes <cluster-name> --project-name <project-name>
+```
+
+**Example:**
+```console
+$ tfcmd get kubernetes mycluster --project-name k8s/mycluster
+1:30PM INF starting peer session=tf-1522842 twin=192
+1:30PM INF kubernetes cluster:
+{
+        "Name": "mycluster",
+        "SolutionType": "kubernetes/mycluster",
+        "Masters": [...],
+        "Workers": [...],
+        "NetworkName": "myclusternetwork"
+}
+```
+
+## Get ZDB
+
+Retrieve information about deployed ZDB (Zero-DB) instances.
+
+```bash
+tfcmd get zdb <zdb-name> --project-name <project-name>
+```
+
+**Example:**
+```console
+$ tfcmd get zdb mydb --project-name db/mydb
+2:45PM INF starting peer session=tf-1522843 twin=192
+2:45PM INF zdb:
+{
+        "Name": "mydb",
+        "SolutionType": "zdb/mydb",
+        "NodeID": 11,
+        "Zdbs": [
+                {
+                        "name": "mydb",
+                        "size": 50,
+                        "mode": "user",
+                        "password": "your-password",
+                        "public": false
+                }
+        ]
+}
+```
+
+## Get Contract
+
+Retrieve information about a specific contract by ID.
+
+```bash
+tfcmd get contract <contract-id>
+```
+
+**Arguments:**
+- `contract-id`: Numeric contract ID
+
+**Example:**
+```console
+$ tfcmd get contract 100063
+3:00PM INF starting peer session=tf-1522844 twin=192
+3:00PM INF contract:
+{
+        "ContractID": 100063,
+        "TwinID": 192,
+        "State": "Created",
+        "SolutionType": "vm.examplevm",
+        "CreatedAt": "2023-12-17T10:30:00Z"
+}
+```
+
+## Get Contracts
+
+List all contracts for your twin (user account).
+
+```bash
+tfcmd get contracts
+```
+
+**Example:**
+```console
+$ tfcmd get contracts
+3:15PM INF starting peer session=tf-1522845 twin=192
+3:15PM INF contracts:
+Contract ID    Type                State    Created At
+100063         vm.examplevm        Created  2023-12-17T10:30:00Z
+100064         gateway.name.myapp  Created  2023-12-17T11:15:00Z
+100065         kubernetes.mycluster Created  2023-12-17T13:00:00Z
+```
+
+## Finding Project Names
+
+Use `get contracts` to discover your existing project names:
+
+```bash
+$ tfcmd get contracts
+# Look at the SolutionType field to find project names
+# vm/examplevm → project name: vm/examplevm
+# gateway.name.myapp → project name: myapp
+```
+
+## Output Formats
+
+### JSON Output (Default)
+All get commands return detailed JSON output with complete deployment information including:
+- Node IDs and network configuration
+- Resource specifications (CPU, memory, disk)
+- IP addresses (public, planetary, mycelium)
+- Environment variables and mount points
+- Contract IDs and deployment status
+
+### Key Fields
+- **Name**: Resource name
+- **NodeID**: Node where resource is deployed
+- **SolutionType**: Project and resource type
+- **NetworkName**: Associated network name
+- **ContractID**: Unique contract identifier
+
+## Use Cases
+
+### Monitoring Deployments
+```bash
+# Check VM status and IP addresses
+tfcmd get vm webserver --project-name production/webapp
+
+# Verify gateway configuration
+tfcmd get gateway name api-gateway --project-name production/api
+```
+
+### Troubleshooting
+```bash
+# Get detailed deployment information
+tfcmd get vm problematic-vm --project-name debug/test
+
+# Check contract status
+tfcmd get contract 123456
+```
+
+### Inventory Management
+```bash
+# List all deployed resources
+tfcmd get contracts
+
+# Get cluster information
+tfcmd get kubernetes production-cluster --project-name k8s/prod
+```
+
+## Breaking Changes
+
+> **Warning**: Get commands now require the `--project-name` flag:
+
+- Old: `tfcmd get vm <name>`
+- New: `tfcmd get vm <name> --project-name <project>`
+
+Use `tfcmd get contracts` to find your existing project names.

--- a/grid-cli/docs/list.md
+++ b/grid-cli/docs/list.md
@@ -1,0 +1,118 @@
+# List Commands
+
+Discover available resources on the ThreeFold Grid.
+
+## List Gateways
+
+### List Name Gateways
+
+List gateway nodes with configured domains for Name Gateway deployments.
+
+```bash
+tfcmd list gateways name [--country <country>] [--farm <id>]
+```
+
+**Flags:**
+- `--country`: Filter by country name (optional)
+- `--farm`: Filter by farm ID (optional)
+
+**Examples:**
+```bash
+# List all name gateways
+tfcmd list gateways name
+
+# Filter by country
+tfcmd list gateways name --country Belgium
+
+# Filter by farm
+tfcmd list gateways name --farm 1
+
+# Combined filters
+tfcmd list gateways name --country Germany --farm 2
+```
+
+**Output:**
+```
+Node ID    Domain                     Farm ID    Country        City
+14         gent01.dev.grid.tf         1          Belgium        Ghent
+15         gent02.dev.grid.tf         1          Belgium        Ghent
+```
+
+---
+
+### List FQDN Gateways
+
+List gateway nodes with public IP addresses for FQDN Gateway deployments.
+
+```bash
+tfcmd list gateways fqdn [--country <country>] [--farm <id>]
+```
+
+**Flags:**
+- `--country`: Filter by country name (optional)
+- `--farm`: Filter by farm ID (optional)
+
+**Examples:**
+```bash
+# List all FQDN gateways
+tfcmd list gateways fqdn
+
+# Filter by country
+tfcmd list gateways fqdn --country Germany
+
+# Combined filters
+tfcmd list gateways fqdn --country Belgium --farm 1
+```
+
+**Output:**
+```
+Node ID    Public IPv4        Public IPv6                           Farm ID    Country        City
+14         185.206.122.33     2a10:b600:1::cc4:c5ff:fe88:2e4d      1          Belgium        Ghent
+15         185.206.122.35     2a10:b600:1::cc4:c5ff:fe88:2e4e      1          Belgium        Ghent
+```
+
+---
+
+## Use Cases
+
+### For Name Gateway Deployments
+
+1. **Discover available domains:**
+   ```bash
+   tfcmd list gateways name
+   ```
+
+2. **Deploy gateway:**
+   ```bash
+   tfcmd deploy gateway name --name myapp --node 14 --backends http://10.20.2.2:8080
+   ```
+
+3. **Your app will be available at:** `myapp.<gateway-domain>`
+
+### For FQDN Gateway Deployments
+
+1. **Find gateway with public IP:**
+   ```bash
+   tfcmd list gateways fqdn
+   ```
+
+2. **Deploy to specific node:**
+   ```bash
+   tfcmd deploy gateway fqdn --name myapp --fqdn myapp.com --node 14 --backends http://10.20.2.2:8080
+   ```
+
+3. **Configure DNS:**
+   ```
+   myapp.com → 185.206.122.33 (the public IPv4 from the list)
+   ```
+
+---
+
+## Gateway Selection Considerations
+
+When selecting a gateway node:
+
+1. **Farm**: Gateway doesn't need to be in same farm as your VM
+2. **Network**: If using private IP backend, specify `--network` so gateway can route to VM
+3. **Location**: Choose gateway close to your users for better latency
+4. **Availability**: Check node uptime and reliability

--- a/grid-cli/docs/login.md
+++ b/grid-cli/docs/login.md
@@ -1,0 +1,243 @@
+# Login
+
+Authenticate with the ThreeFold Grid using your mnemonic phrase.
+
+## Login Command
+
+```bash
+tfcmd login
+```
+
+The login command provides an interactive authentication flow that prompts you for:
+- **Mnemonic phrase**: Your 12 or 24-word seed phrase
+- **Network selection**: Choose between mainnet, testnet, devnet, or QA network
+
+## Interactive Login Process
+
+### Step 1: Enter Mnemonic
+```console
+$ tfcmd login
+Enter your mnemonic phrase (12 or 24 words):
+```
+
+Paste your mnemonic phrase when prompted. The phrase will be hidden for security.
+
+### Step 2: Select Network
+```console
+Select network:
+1) mainnet
+2) testnet  
+3) devnet
+4) qa
+Enter choice (1-4):
+```
+
+Choose the appropriate network for your deployment:
+- **mainnet**: Production environment with real costs
+- **testnet**: Testing environment with free resources
+- **devnet**: Development environment
+- **qa**: Quality assurance environment
+
+### Step 3: Confirmation
+```console
+Login successful! Configuration saved to ~/.config/tfgrid/config.yaml
+Network: testnet
+Twin ID: 192
+```
+
+## Configuration Storage
+
+Your credentials and network selection are saved locally in:
+```
+~/.config/tfgrid/config.yaml
+```
+
+This file contains:
+- Encrypted mnemonic phrase
+- Selected network
+- Twin ID (automatically retrieved)
+- Account information
+
+## Network Options
+
+### Mainnet
+- **Purpose**: Production deployments
+- **Costs**: Real TFT tokens required
+- **Resources**: Full production capacity
+- **Use Case**: Production applications and services
+
+### Testnet
+- **Purpose**: Testing and development
+- **Costs**: Free testnet tokens
+- **Resources**: Limited but sufficient for testing
+- **Use Case**: Application testing and development
+
+### Devnet
+- **Purpose**: Development and experimentation
+- **Costs**: Free
+- **Resources**: Development environment
+- **Use Case**: Feature development and debugging
+
+### QA
+- **Purpose**: Quality assurance and testing
+- **Costs**: Free
+- **Resources**: QA environment
+- **Use Case**: Pre-production testing
+
+## Security Considerations
+
+### Mnemonic Security
+- ✅ **Never share your mnemonic** with anyone
+- ✅ **Store it securely** offline
+- ✅ **Use different mnemonics** for different networks
+- ❌ **Don't commit to version control**
+- ❌ **Don't share in screenshots or logs**
+
+### Configuration File
+- ✅ **Locally stored** on your machine only
+- ✅ **Encrypted at rest**
+- ✅ **Permissions restricted** to user only
+- ❌ **Don't share the config file**
+
+## Troubleshooting
+
+### Common Issues
+
+#### Invalid Mnemonic
+```console
+Error: invalid mnemonic phrase
+```
+**Solution**: Verify your mnemonic phrase is correct (12 or 24 words)
+
+#### Network Connection
+```console
+Error: failed to connect to grid network
+```
+**Solution**: Check internet connection and network availability
+
+#### Twin Not Found
+```console
+Error: twin not found for this mnemonic
+```
+**Solution**: Ensure you've created a twin on the selected network
+
+### Reset Configuration
+If you need to reset your configuration:
+```bash
+# Remove configuration file
+rm ~/.config/tfgrid/config.yaml
+
+# Login again
+tfcmd login
+```
+
+### Switch Networks
+To switch to a different network:
+```bash
+# Remove current configuration
+rm ~/.config/tfgrid/config.yaml
+
+# Login and select new network
+tfcmd login
+```
+
+## Advanced Usage
+
+### Environment Variables
+You can set these environment variables to customize behavior:
+
+```bash
+# Override config location
+export TFGRID_CONFIG_DIR=/custom/path
+
+# Disable sentry error reporting
+export TFGRID_DISABLE_SENTRY=true
+```
+
+### Multiple Accounts
+For multiple accounts, use different configuration directories:
+```bash
+# Account 1
+TFGRID_CONFIG_DIR=~/.tfgrid/account1 tfcmd login
+
+# Account 2  
+TFGRID_CONFIG_DIR=~/.tfgrid/account2 tfcmd login
+```
+
+## Verification
+
+After login, verify your configuration:
+
+### Check Twin ID
+```bash
+# Your twin ID is shown in login confirmation
+# Or check with any command
+tfcmd get contracts
+```
+
+### Test Connection
+```bash
+# Test basic connectivity
+tfcmd list gateways name
+```
+
+### Verify Network
+```bash
+# Check you're on the right network
+# (Different networks have different available resources)
+tfcmd list gateways name --farm 1
+```
+
+## Wallet Connector Integration
+
+If you don't have mnemonics yet, you can:
+1. Use the [ThreeFold Wallet Connector](https://manual.grid.tf/documentation/dashboard/wallet_connector.html)
+2. Create a new wallet
+3. Export your mnemonic phrase
+4. Use it with `tfcmd login`
+
+## Best Practices
+
+### Development Workflow
+```bash
+# 1. Use testnet for development
+tfcmd login
+# Select: testnet
+
+# 2. Test deployments
+tfcmd deploy vm --name test --ssh ~/.ssh/id_rsa.pub
+
+# 3. Cleanup
+tfcmd cancel --project-name vm/test
+```
+
+### Production Workflow
+```bash
+# 1. Use mainnet for production
+tfcmd login  
+# Select: mainnet
+
+# 2. Verify TFT balance
+# (Check your wallet has sufficient TFT)
+
+# 3. Deploy production resources
+tfcmd deploy vm --name prod --ssh ~/.ssh/id_rsa.pub --cpu 4 --memory 8
+```
+
+### Security Checklist
+- [ ] Mnemonic stored securely offline
+- [ ] Different mnemonics for mainnet/testnet
+- [ ] Config file permissions set correctly
+- [ ] Regular backup of configuration
+- [ ] Never share credentials in logs/screenshots
+
+## Getting Help
+
+If you encounter issues:
+1. Check network connectivity
+2. Verify mnemonic phrase
+3. Ensure twin exists on selected network
+4. Try resetting configuration
+5. Contact ThreeFold support
+
+For more information about mnemonics and wallet setup, see the [ThreeFold documentation](https://manual.grid.tf/documentation/dashboard/wallet_connector.html).

--- a/grid-cli/docs/update.md
+++ b/grid-cli/docs/update.md
@@ -1,0 +1,375 @@
+# Update Commands
+
+Update and manage deployed resources on the ThreeFold Grid.
+
+## Update Kubernetes
+
+Manage Kubernetes cluster workers (add or remove nodes).
+
+### Add Worker Node
+
+Add a new worker node to an existing Kubernetes cluster.
+
+```bash
+tfcmd update kubernetes add-worker [flags]
+```
+
+**Required Flags:**
+- `--cluster-name`: Name of the Kubernetes cluster
+- `--project-name`: Project name of the cluster
+- `--node`: Node ID where to deploy the worker
+- `--ssh`: Path to SSH public key
+
+**Optional Flags:**
+- `--disk`: Worker disk size (default: 50GB)
+- `--memory`: Worker memory size (default: 4GB)
+- `--farm`: Farm ID for node selection (if not using --node)
+
+**Example:**
+```console
+$ tfcmd update kubernetes add-worker \
+  --cluster-name mycluster \
+  --project-name k8s/mycluster \
+  --node 15 \
+  --ssh ~/.ssh/id_rsa.pub \
+  --disk 100 \
+  --memory 8
+2:30PM INF starting peer session=tf-1522850 twin=192
+2:30PM INF adding worker to kubernetes cluster 'mycluster'
+2:31PM INF successfully added worker to cluster
+```
+
+### Delete Worker Node
+
+Remove a worker node from a Kubernetes cluster.
+
+```bash
+tfcmd update kubernetes delete-worker [flags]
+```
+
+**Required Flags:**
+- `--cluster-name`: Name of the Kubernetes cluster
+- `--project-name`: Project name of the cluster
+- `--worker-node`: Node ID of worker to remove
+
+**Example:**
+```console
+$ tfcmd update kubernetes delete-worker \
+  --cluster-name mycluster \
+  --project-name k8s/mycluster \
+  --worker-node 15
+2:45PM INF starting peer session=tf-1522851 twin=192
+2:45PM INF removing worker node 15 from kubernetes cluster 'mycluster'
+2:46PM INF successfully removed worker from cluster
+```
+
+## Cluster Management
+
+### Scaling Workers
+
+Add multiple workers to scale your cluster:
+
+```bash
+# Add first worker
+tfcmd update kubernetes add-worker \
+  --cluster-name production \
+  --project-name k8s/production \
+  --node 11 \
+  --ssh ~/.ssh/id_rsa.pub
+
+# Add second worker  
+tfcmd update kubernetes add-worker \
+  --cluster-name production \
+  --project-name k8s/production \
+  --node 12 \
+  --ssh ~/.ssh/id_rsa.pub
+
+# Add third worker
+tfcmd update kubernetes add-worker \
+  --cluster-name production \
+  --project-name k8s/production \
+  --node 13 \
+  --ssh ~/.ssh/id_rsa.pub
+```
+
+### Worker Configuration
+
+Customize worker specifications:
+
+```bash
+# High-memory worker for databases
+tfcmd update kubernetes add-worker \
+  --cluster-name db-cluster \
+  --project-name k8s/db-cluster \
+  --node 14 \
+  --ssh ~/.ssh/id_rsa.pub \
+  --memory 16 \
+  --disk 200
+
+# Compute worker for CPU-intensive tasks
+tfcmd update kubernetes add-worker \
+  --cluster-name compute-cluster \
+  --project-name k8s/compute-cluster \
+  --node 15 \
+  --ssh ~/.ssh/id_rsa.pub \
+  --memory 4 \
+  --disk 50
+```
+
+## Finding Clusters and Nodes
+
+### List Your Clusters
+```bash
+# Get all contracts to find your clusters
+tfcmd get contracts
+
+# Look for kubernetes.* solution types
+# k8s/mycluster → project name: k8s/mycluster
+```
+
+### Get Cluster Details
+```bash
+# Get current cluster information
+tfcmd get kubernetes mycluster --project-name k8s/mycluster
+
+# Check current workers and their nodes
+```
+
+### Find Available Nodes
+```bash
+# List nodes in a specific farm
+tfcmd list gateways name --farm 1
+
+# Or check node status directly
+# (Node IDs should be known from your infrastructure planning)
+```
+
+## Worker Node Requirements
+
+### Minimum Specifications
+- **CPU**: 2 vCPUs
+- **Memory**: 4GB RAM
+- **Disk**: 50GB storage
+- **Network**: Same farm as master nodes
+
+### Recommended Specifications
+- **Production workers**: 4+ vCPUs, 8GB+ RAM, 100GB+ disk
+- **Development workers**: 2 vCPUs, 4GB RAM, 50GB disk
+- **Database workers**: 4+ vCPUs, 16GB+ RAM, 200GB+ disk
+
+### Network Requirements
+- **Same farm**: Workers must be in same farm as cluster
+- **Network access**: Must be able to join cluster network
+- **Connectivity**: Must reach master nodes on private network
+
+## Use Cases
+
+### Horizontal Scaling
+```bash
+# Scale out for increased capacity
+tfcmd update kubernetes add-worker \
+  --cluster-name webapp \
+  --project-name k8s/webapp \
+  --node 16 \
+  --ssh ~/.ssh/id_rsa.pub
+
+# Scale down to reduce costs
+tfcmd update kubernetes delete-worker \
+  --cluster-name webapp \
+  --project-name k8s/webapp \
+  --worker-node 13
+```
+
+### Node Maintenance
+```bash
+# Replace failing node
+# 1. Add new worker
+tfcmd update kubernetes add-worker \
+  --cluster-name production \
+  --project-name k8s/production \
+  --node 17 \
+  --ssh ~/.ssh/id_rsa.pub
+
+# 2. Drain old node (kubectl drain nodeXX)
+# 3. Delete old worker
+tfcmd update kubernetes delete-worker \
+  --cluster-name production \
+  --project-name k8s/production \
+  --worker-node 12
+```
+
+### Workload Separation
+```bash
+# Add dedicated database workers
+tfcmd update kubernetes add-worker \
+  --cluster-name production \
+  --project-name k8s/production \
+  --node 18 \
+  --ssh ~/.ssh/id_rsa.pub \
+  --memory 16 \
+  --disk 200
+
+# Add dedicated compute workers
+tfcmd update kubernetes add-worker \
+  --cluster-name production \
+  --project-name k8s/production \
+  --node 19 \
+  --ssh ~/.ssh/id_rsa.pub \
+  --memory 8 \
+  --disk 100
+```
+
+## Monitoring and Verification
+
+### Check Cluster Status
+```bash
+# Get updated cluster information
+tfcmd get kubernetes mycluster --project-name k8s/mycluster
+
+# Verify new workers are listed
+```
+
+### Kubernetes Verification
+```bash
+# After adding workers, verify in kubectl
+kubectl get nodes
+# Should show new worker nodes
+
+# Check node status
+kubectl describe node <new-worker-node>
+```
+
+### Network Verification
+```bash
+# Test connectivity between nodes
+# Use kubectl to test pod networking
+kubectl run test-pod --image=busybox --rm -it -- /bin/sh
+# ping other node IPs
+```
+
+## Troubleshooting
+
+### Common Issues
+
+#### Worker Fails to Join Cluster
+```bash
+Error: worker failed to join kubernetes cluster
+```
+**Solutions:**
+- Check network connectivity between nodes
+- Verify worker is in same farm as master
+- Check SSH key configuration
+- Verify cluster network configuration
+
+#### Node Not Available
+```bash
+Error: node 15 is not available
+```
+**Solutions:**
+- Check if node exists and is online
+- Verify node has sufficient resources
+- Try a different node in the same farm
+
+#### Project Not Found
+```bash
+Error: project k8s/mycluster not found
+```
+**Solutions:**
+- Check project name with `tfcmd get contracts`
+- Verify cluster was deployed successfully
+- Use correct project name format
+
+### Recovery Operations
+
+#### Failed Worker Addition
+```bash
+# If worker addition fails, check cluster status
+tfcmd get kubernetes mycluster --project-name k8s/mycluster
+
+# Remove any partially created workers
+tfcmd update kubernetes delete-worker \
+  --cluster-name mycluster \
+  --project-name k8s/mycluster \
+  --worker-node <failed-node-id>
+```
+
+#### Cluster Corruption
+```bash
+# If cluster is corrupted, you may need to:
+# 1. Cancel entire deployment
+tfcmd cancel --project-name k8s/mycluster
+
+# 2. Deploy new cluster
+tfcmd deploy kubernetes --name mycluster --project-name k8s/mycluster ...
+
+# 3. Add workers back
+tfcmd update kubernetes add-worker ...
+```
+
+## Best Practices
+
+### Production Deployment
+```bash
+# Use consistent worker specifications
+tfcmd update kubernetes add-worker \
+  --cluster-name production \
+  --project-name k8s/production \
+  --node 20 \
+  --ssh ~/.ssh/id_rsa.pub \
+  --memory 8 \
+  --disk 100
+
+# Document worker configurations
+# Monitor worker health
+# Plan node maintenance windows
+```
+
+### Cost Optimization
+```bash
+# Scale down during off-peak hours
+tfcmd update kubernetes delete-worker \
+  --cluster-name dev-cluster \
+  --project-name k8s/dev-cluster \
+  --worker-node 21
+
+# Scale up when needed
+tfcmd update kubernetes add-worker \
+  --cluster-name dev-cluster \
+  --project-name k8s/dev-cluster \
+  --node 22 \
+  --ssh ~/.ssh/id_rsa.pub
+```
+
+### Security Considerations
+- Use consistent SSH keys across workers
+- Monitor worker node access
+- Regular security updates on workers
+- Network segmentation between clusters
+
+## Integration with kubectl
+
+After updating workers, use kubectl to manage the Kubernetes cluster:
+
+```bash
+# Get cluster credentials (if applicable)
+# (This depends on your Kubernetes setup)
+
+# Verify new workers
+kubectl get nodes
+
+# Schedule workloads on new workers
+kubectl label nodes <worker-node> workload-type=database
+
+# Remove old workers gracefully
+kubectl drain <old-worker-node>
+```
+
+## Future Updates
+
+The update command may expand to support:
+- VM resource updates
+- Gateway configuration updates  
+- ZDB capacity modifications
+- Network configuration changes
+
+Check `tfcmd update --help` for the latest available update operations.

--- a/grid-cli/docs/version.md
+++ b/grid-cli/docs/version.md
@@ -1,0 +1,202 @@
+# Version
+
+Display version information about the tfcmd binary.
+
+## Version Command
+
+```bash
+tfcmd version
+```
+
+Shows the current version, build information, and git commit details.
+
+## Example Output
+
+```console
+$ tfcmd version
+tfcmd version 1.2.3
+Build date: 2023-12-17T10:30:00Z
+Git commit: a1b2c3d4e5f6789abcdef1234567890abcdef12
+Go version: go1.21.1
+```
+
+## Output Fields
+
+- **Version**: Semantic version number (e.g., 1.2.3)
+- **Build date**: When the binary was built
+- **Git commit**: Full git commit hash of the source
+- **Go version**: Go language version used to build
+
+## Use Cases
+
+### Checking Installation
+```bash
+# Verify tfcmd is installed and working
+tfcmd version
+```
+
+### Bug Reporting
+Include version information when reporting issues:
+```bash
+$ tfcmd version
+# Include this output in bug reports
+```
+
+### Version Compatibility
+Check if you have the latest version:
+```bash
+# Compare your version with latest releases
+tfcmd version
+# Check: https://github.com/threefoldtech/tfgrid-sdk-go/releases
+```
+
+### Troubleshooting
+Version information helps diagnose:
+- Build-specific issues
+- Feature availability
+- Compatibility problems
+
+## Version Format
+
+The version follows [semantic versioning](https://semver.org/):
+- **MAJOR**: Breaking changes
+- **MINOR**: New features (backward compatible)
+- **PATCH**: Bug fixes (backward compatible)
+
+Example: `1.2.3`
+- `1`: Major version
+- `2`: Minor version  
+- `3`: Patch version
+
+## Update Process
+
+To update to the latest version:
+
+1. **Check current version**:
+   ```bash
+   tfcmd version
+   ```
+
+2. **Download latest release**:
+   ```bash
+   # Visit: https://github.com/threefoldtech/tfgrid-sdk-go/releases
+   # Download the latest binary for your platform
+   ```
+
+3. **Replace binary**:
+   ```bash
+   # Backup old version
+   mv /usr/local/bin/tfcmd /usr/local/bin/tfcmd.backup
+   
+   # Install new version
+   mv tfcmd /usr/local/bin/tfcmd
+   chmod +x /usr/local/bin/tfcmd
+   ```
+
+4. **Verify update**:
+   ```bash
+   tfcmd version
+   ```
+
+## Build from Source
+
+If you build from source, version information is automatically included:
+
+```bash
+# Clone repository
+git clone https://github.com/threefoldtech/tfgrid-sdk-go.git
+cd tfgrid-sdk-go/grid-cli
+
+# Build
+make build
+
+# Check version
+./tfcmd version
+```
+
+## Development Versions
+
+Development builds may include:
+- Pre-release tags (e.g., `1.2.3-alpha.1`)
+- Commit hash instead of version
+- Build metadata
+
+Example development output:
+```console
+$ tfcmd version
+tfcmd version 1.2.3-alpha.1+dev.a1b2c3d
+Build date: 2023-12-17T10:30:00Z
+Git commit: a1b2c3d4e5f6789abcdef1234567890abcdef12
+Go version: go1.21.1
+```
+
+## Troubleshooting
+
+### Version Not Showing
+```bash
+$ tfcmd version
+Error: version information not available
+```
+**Solutions:**
+- Binary may be corrupted - reinstall
+- Build may not include version info - rebuild with proper flags
+
+### Old Version
+If you have an old version and need features:
+1. Check current version: `tfcmd version`
+2. Download latest release
+3. Install as shown in update process
+
+### Version Conflicts
+Multiple tfcmd installations can cause conflicts:
+```bash
+# Check which tfcmd is being used
+which tfcmd
+# Expected: /usr/local/bin/tfcmd
+
+# Check all versions
+/usrusr/local/bin/tfcmd version
+~/bin/tfcmd version
+```
+
+## Integration with Scripts
+
+Use version information in scripts for compatibility checks:
+
+```bash
+#!/bin/bash
+# Check tfcmd version compatibility
+
+REQUIRED_VERSION="1.2.0"
+CURRENT_VERSION=$(tfcmd version | head -1 | cut -d' ' -f3)
+
+if [ "$(printf '%s\n' "$REQUIRED_VERSION" "$CURRENT_VERSION" | sort -V | head -n1)" != "$REQUIRED_VERSION" ]; then
+    echo "Error: tfcmd version $CURRENT_VERSION is too old. Required: $REQUIRED_VERSION or newer"
+    exit 1
+fi
+
+echo "tfcmd version $CURRENT_VERSION is compatible"
+```
+
+## Release Notes
+
+Version information corresponds to official releases:
+- **Main releases**: Stable features and bug fixes
+- **Pre-releases**: Alpha/beta testing versions
+- **Development builds**: Latest features (may be unstable)
+
+Check the [GitHub releases](https://github.com/threefoldtech/tfgrid-sdk-go/releases) for:
+- Release notes
+- Breaking changes
+- New features
+- Bug fixes
+
+## Getting Help
+
+If version-related issues occur:
+1. Verify you have the latest version
+2. Check release notes for breaking changes
+3. Report issues with version information included
+4. Consider building from source for latest features
+
+For the most up-to-date information, always check the official ThreeFold documentation and GitHub releases.

--- a/grid-cli/docs/vm.md
+++ b/grid-cli/docs/vm.md
@@ -36,6 +36,7 @@ tfcmd deploy vm [flags]
 ### Project Names and Networks
 
 When deploying a VM:
+
 - If `--project-name` is not specified, it defaults to `vm/{vmname}`
 - The network name is derived from the project name (e.g., project `vm/myapp` creates network `myappnetwork`)
 - Multiple VMs can share the same project and network by using the same `--project-name` and `--network`
@@ -48,16 +49,35 @@ When deploying a VM:
 - ❌ Node 327 (Farm 2) cannot join Farm 1's network
 
 For cross-farm deployments:
+
 - Use separate networks per farm
 - Use planetary network IPs for inter-VM communication
 
 ### Disks vs Volumes
 
-- **Disks**: Local SSD storage on the node (faster, not shared between VMs)
-- **Volumes**: Distributed QSFS storage (slower, can be shared across VMs)
+- **Disks (zmount)**: Legacy sparse files on host filesystem (slower, being deprecated)
+- **Volumes**: Modern btrfs subvolumes with quota (faster, future of storage)
 
-Use disks for: databases, caches, temporary files  
-Use volumes for: shared data, backups, large files
+**Key Advantages of Volumes:**
+- ✅ **Better Performance**: Direct subvolume access vs sparse files
+- ✅ **Snapshots**: Backups without interrupting the VM
+- ✅ **Live Resize**: Grow/shrink while VM is running
+- ✅ **Better Caching**: Optimized storage utilization
+- ✅ **Future-Proof**: Will migrate to bcachefs
+
+**Migration Path:**
+```
+Past:    zmount (sparse files) ❌ Legacy
+Present: btrfs subvolumes ✅ Current  
+Future:  bcachefs ✅ Next Generation
+```
+
+**Recommendation:**
+
+- Use **volumes** for all new deployments (future-proof)
+- Use **disks** only for backward compatibility (will be deprecated)
+
+> **Note**: QSFS is a separate distributed storage technology and is NOT related to volumes. Volumes are local storage.
 
 Example:
 

--- a/grid-cli/docs/vm.md
+++ b/grid-cli/docs/vm.md
@@ -40,6 +40,25 @@ When deploying a VM:
 - The network name is derived from the project name (e.g., project `vm/myapp` creates network `myappnetwork`)
 - Multiple VMs can share the same project and network by using the same `--project-name` and `--network`
 
+### Network Limitations
+
+**IMPORTANT**: Networks can only span nodes within the same farm.
+
+- ✅ Nodes 11 and 14 (both in Farm 1) can share a network
+- ❌ Node 327 (Farm 2) cannot join Farm 1's network
+
+For cross-farm deployments:
+- Use separate networks per farm
+- Use planetary network IPs for inter-VM communication
+
+### Disks vs Volumes
+
+- **Disks**: Local SSD storage on the node (faster, not shared between VMs)
+- **Volumes**: Distributed QSFS storage (slower, can be shared across VMs)
+
+Use disks for: databases, caches, temporary files  
+Use volumes for: shared data, backups, large files
+
 Example:
 
 - Deploying VM without GPU

--- a/grid-cli/go.mod
+++ b/grid-cli/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/threefoldtech/tfgrid-sdk-go/grid-client v0.17.5
-	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.0
+	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.5
 	github.com/threefoldtech/zosbase v1.0.4
 	github.com/vedhavyas/go-subkey v1.0.3
 )

--- a/grid-cli/go.sum
+++ b/grid-cli/go.sum
@@ -127,8 +127,8 @@ github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
 github.com/threefoldtech/tfgrid-sdk-go/grid-client v0.17.5 h1:uyLQNxE6DikMsi7AujbBY6bZWSTRMAnBPXJE5iT5K/U=
 github.com/threefoldtech/tfgrid-sdk-go/grid-client v0.17.5/go.mod h1:pDqAGlLPD1LyBvJy90B7DhQ5HWGrz2tyj1YNO6Cc6tI=
-github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.0 h1:Z5IlF+B0N02myvos8TjsVZbF/VkFCJ7CbEUJwMyLnF4=
-github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.0/go.mod h1:DWvKZtNjED/soFjKs1zUcOtPCf52uVjj94SyFtaLsas=
+github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.5 h1:ZHjXH/b9MLFKMhtDBfVPov/UjBwpjFDB+J0m2Tz1BA0=
+github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.5/go.mod h1:VxjCKht0QTbwZd4LkhIhIinLKHCP5xYjXMoSgdbHmS8=
 github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.5 h1:zp5iZOvtvcQrcR7Po3UZBNk2uBYi1i1VxMA/ENIvCZY=
 github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.5/go.mod h1:T+PZydVl3fxywqoUhCmzs+hUarfE1q9IMRl9xa+GIYo=
 github.com/threefoldtech/zosbase v1.0.4 h1:A4kFukh4IO5r5e9F51aqKgXOyTG5cWknxqEVGtQ647w=

--- a/grid-cli/internal/cmd/deploy.go
+++ b/grid-cli/internal/cmd/deploy.go
@@ -21,6 +21,15 @@ func DeployVM(ctx context.Context, t deployer.TFPluginClient, vm workloads.VM, d
 	var network workloads.ZNet
 	var err error
 
+	// Validate: deployment name must be unique within the project
+	exists, err := DeploymentExists(t, projectName, vm.Name)
+	if err != nil {
+		return workloads.VM{}, errors.Wrapf(err, "failed to check if deployment '%s' exists", vm.Name)
+	}
+	if exists {
+		return workloads.VM{}, fmt.Errorf("deployment '%s' already exists in project '%s'", vm.Name, projectName)
+	}
+
 	if existingNetworkName != "" {
 		// Use existing network
 		networkName = existingNetworkName
@@ -31,8 +40,6 @@ func DeployVM(ctx context.Context, t deployer.TFPluginClient, vm workloads.VM, d
 		if err != nil {
 			return workloads.VM{}, errors.Wrapf(err, "failed to load existing network '%s'", networkName)
 		}
-
-		// Add VM node to network if not already present
 		if !slices.Contains(network.Nodes, vm.NodeID) {
 			log.Info().Msgf("adding node %d to network '%s'", vm.NodeID, networkName)
 			network.Nodes = append(network.Nodes, vm.NodeID)
@@ -42,6 +49,9 @@ func DeployVM(ctx context.Context, t deployer.TFPluginClient, vm workloads.VM, d
 				key, err := workloads.RandomMyceliumKey()
 				if err != nil {
 					return workloads.VM{}, err
+				}
+				if network.MyceliumKeys == nil {
+					network.MyceliumKeys = make(map[uint32][]byte)
 				}
 				network.MyceliumKeys[vm.NodeID] = key
 			}
@@ -61,6 +71,15 @@ func DeployVM(ctx context.Context, t deployer.TFPluginClient, vm workloads.VM, d
 			baseName = projectName[idx+1:]
 		}
 		networkName = fmt.Sprintf("%snetwork", baseName)
+
+		// Validate: network name must be unique for this user
+		exists, existingProject, err := NetworkExistsForUser(t, networkName)
+		if err != nil {
+			return workloads.VM{}, errors.Wrapf(err, "failed to check if network '%s' exists", networkName)
+		}
+		if exists {
+			return workloads.VM{}, fmt.Errorf("network '%s' already exists in project '%s'. Use --network flag to join existing network or choose a different project name", networkName, existingProject)
+		}
 
 		network, err = buildNetwork(networkName, projectName, []uint32{vm.NodeID}, len(vm.MyceliumIPSeed) != 0)
 		if err != nil {
@@ -103,6 +122,15 @@ func DeployVMLight(ctx context.Context, t deployer.TFPluginClient, vm workloads.
 	var network workloads.ZNetLight
 	var err error
 
+	// Validate: deployment name must be unique within the project
+	exists, err := DeploymentExists(t, projectName, vm.Name)
+	if err != nil {
+		return workloads.VMLight{}, errors.Wrapf(err, "failed to check if deployment '%s' exists", vm.Name)
+	}
+	if exists {
+		return workloads.VMLight{}, fmt.Errorf("deployment '%s' already exists in project '%s'", vm.Name, projectName)
+	}
+
 	if existingNetworkName != "" {
 		// Use existing network
 		networkName = existingNetworkName
@@ -124,6 +152,9 @@ func DeployVMLight(ctx context.Context, t deployer.TFPluginClient, vm workloads.
 			if err != nil {
 				return workloads.VMLight{}, err
 			}
+			if network.MyceliumKeys == nil {
+				network.MyceliumKeys = make(map[uint32][]byte)
+			}
 			network.MyceliumKeys[vm.NodeID] = key
 
 			// Redeploy network with new node
@@ -141,6 +172,15 @@ func DeployVMLight(ctx context.Context, t deployer.TFPluginClient, vm workloads.
 			baseName = projectName[idx+1:]
 		}
 		networkName = fmt.Sprintf("%snetwork", baseName)
+
+		// Validate: network name must be unique for this user
+		exists, existingProject, err := NetworkExistsForUser(t, networkName)
+		if err != nil {
+			return workloads.VMLight{}, errors.Wrapf(err, "failed to check if network '%s' exists", networkName)
+		}
+		if exists {
+			return workloads.VMLight{}, fmt.Errorf("network '%s' already exists in project '%s'. Use --network flag to join existing network or choose a different project name", networkName, existingProject)
+		}
 
 		network, err = buildNetworkLight(networkName, projectName, []uint32{vm.NodeID})
 		if err != nil {
@@ -239,6 +279,40 @@ func DeployKubernetesCluster(ctx context.Context, t deployer.TFPluginClient, mas
 
 // DeployGatewayName deploys a gateway name
 func DeployGatewayName(ctx context.Context, t deployer.TFPluginClient, gateway workloads.GatewayNameProxy) (workloads.GatewayNameProxy, error) {
+	// If network is specified, ensure gateway node is part of the network
+	if gateway.Network != "" {
+		log.Info().Msgf("checking if gateway node %d is part of network '%s'", gateway.NodeID, gateway.Network)
+
+		// Load the network - use SolutionType (project name) to find it
+		network, err := GetNetwork(ctx, t, gateway.SolutionType, gateway.Network)
+		if err != nil {
+			return workloads.GatewayNameProxy{}, errors.Wrapf(err, "failed to load network '%s'", gateway.Network)
+		}
+
+		// Check if gateway node is already in the network
+		if !slices.Contains(network.Nodes, gateway.NodeID) {
+			log.Info().Msgf("extending network '%s' to include gateway node %d", gateway.Network, gateway.NodeID)
+			network.Nodes = append(network.Nodes, gateway.NodeID)
+
+			// Add mycelium key for the gateway node
+			key, err := workloads.RandomMyceliumKey()
+			if err != nil {
+				return workloads.GatewayNameProxy{}, err
+			}
+			if network.MyceliumKeys == nil {
+				network.MyceliumKeys = make(map[uint32][]byte)
+			}
+			network.MyceliumKeys[gateway.NodeID] = key
+
+			// Redeploy network with gateway node
+			log.Info().Msg("updating network")
+			err = t.NetworkDeployer.Deploy(ctx, &network)
+			if err != nil {
+				return workloads.GatewayNameProxy{}, errors.Wrapf(err, "failed to extend network to gateway node %d", gateway.NodeID)
+			}
+		}
+	}
+
 	log.Info().Msg("deploying gateway name")
 	err := t.GatewayNameDeployer.Deploy(ctx, &gateway)
 	if err != nil {
@@ -250,6 +324,40 @@ func DeployGatewayName(ctx context.Context, t deployer.TFPluginClient, gateway w
 
 // DeployGatewayFQDN deploys a gateway fqdn
 func DeployGatewayFQDN(ctx context.Context, t deployer.TFPluginClient, gateway workloads.GatewayFQDNProxy) error {
+	// If network is specified, ensure gateway node is part of the network
+	if gateway.Network != "" {
+		log.Info().Msgf("checking if gateway node %d is part of network '%s'", gateway.NodeID, gateway.Network)
+
+		// Load the network - use SolutionType (project name) to find it
+		network, err := GetNetwork(ctx, t, gateway.SolutionType, gateway.Network)
+		if err != nil {
+			return errors.Wrapf(err, "failed to load network '%s'", gateway.Network)
+		}
+
+		// Check if gateway node is already in the network
+		if !slices.Contains(network.Nodes, gateway.NodeID) {
+			log.Info().Msgf("extending network '%s' to include gateway node %d", gateway.Network, gateway.NodeID)
+			network.Nodes = append(network.Nodes, gateway.NodeID)
+
+			// Add mycelium key for the gateway node
+			key, err := workloads.RandomMyceliumKey()
+			if err != nil {
+				return err
+			}
+			if network.MyceliumKeys == nil {
+				network.MyceliumKeys = make(map[uint32][]byte)
+			}
+			network.MyceliumKeys[gateway.NodeID] = key
+
+			// Redeploy network with gateway node
+			log.Info().Msg("updating network")
+			err = t.NetworkDeployer.Deploy(ctx, &network)
+			if err != nil {
+				return errors.Wrapf(err, "failed to extend network to gateway node %d", gateway.NodeID)
+			}
+		}
+	}
+
 	log.Info().Msg("deploying gateway fqdn")
 	err := t.GatewayFQDNDeployer.Deploy(ctx, &gateway)
 	if err != nil {

--- a/grid-cli/internal/cmd/get.go
+++ b/grid-cli/internal/cmd/get.go
@@ -22,24 +22,19 @@ func checkIfExistAndAppend(t deployer.TFPluginClient, node uint32, contractID ui
 
 // GetVM gets a VM by project name and VM name
 func GetVM(ctx context.Context, t deployer.TFPluginClient, projectName, name string) (workloads.Deployment, error) {
-	contracts, err := t.ContractsGetter.ListContractsOfProjectName(projectName, true)
+	nodeContractIDs, err := t.ContractsGetter.GetNodeContractsByTypeAndName(projectName, workloads.VMType, name)
 	if err != nil {
 		return workloads.Deployment{}, err
 	}
 
-	if len(contracts.NodeContracts) == 0 {
+	if len(nodeContractIDs) == 0 {
 		return workloads.Deployment{}, fmt.Errorf("no contracts found for VM '%s' in project '%s'", name, projectName)
 	}
 
 	var nodeID uint32
-	for _, contract := range contracts.NodeContracts {
-		contractID, err := strconv.ParseUint(contract.ContractID, 10, 64)
-		if err != nil {
-			return workloads.Deployment{}, err
-		}
-
-		nodeID = contract.NodeID
-		checkIfExistAndAppend(t, nodeID, contractID)
+	for node, contractID := range nodeContractIDs {
+		checkIfExistAndAppend(t, node, contractID)
+		nodeID = node
 	}
 
 	return t.State.LoadDeploymentFromGrid(ctx, nodeID, name)

--- a/grid-cli/internal/cmd/get.go
+++ b/grid-cli/internal/cmd/get.go
@@ -10,14 +10,18 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
 )
 
-func checkIfExistAndAppend(t deployer.TFPluginClient, node uint32, contractID uint64) {
-	for _, n := range t.State.CurrentNodeDeployments[node] {
-		if n == contractID {
-			return
+// checkIfExistAndAppend checks if a contract exists in CurrentNodeDeployments and adds it if not
+func checkIfExistAndAppend(t deployer.TFPluginClient, nodeID uint32, contractID uint64) {
+	if contractIDs, exists := t.State.CurrentNodeDeployments[nodeID]; exists {
+		for _, id := range contractIDs {
+			if id == contractID {
+				return // Contract already exists
+			}
 		}
+		t.State.CurrentNodeDeployments[nodeID] = append(contractIDs, contractID)
+	} else {
+		t.State.CurrentNodeDeployments[nodeID] = []uint64{contractID}
 	}
-
-	t.State.CurrentNodeDeployments[node] = append(t.State.CurrentNodeDeployments[node], contractID)
 }
 
 // GetVM gets a VM by project name and VM name
@@ -42,6 +46,7 @@ func GetVM(ctx context.Context, t deployer.TFPluginClient, projectName, name str
 
 // GetK8sCluster gets a Kubernetes cluster by project name and cluster name
 func GetK8sCluster(ctx context.Context, t deployer.TFPluginClient, projectName, name string) (workloads.K8sCluster, error) {
+	// Get all contracts for the project
 	contracts, err := t.ContractsGetter.ListContractsOfProjectName(projectName, true)
 	if err != nil {
 		return workloads.K8sCluster{}, err
@@ -51,56 +56,110 @@ func GetK8sCluster(ctx context.Context, t deployer.TFPluginClient, projectName, 
 		return workloads.K8sCluster{}, fmt.Errorf("no contracts found for cluster '%s' in project '%s'", name, projectName)
 	}
 
+	// Filter contracts to only include those belonging to this specific cluster
+	// Kubernetes clusters have multiple contracts (master + workers) with the same cluster name
 	var nodeIDs []uint32
 	for _, contract := range contracts.NodeContracts {
-		contractID, err := strconv.ParseUint(contract.ContractID, 10, 64)
+		deploymentData, err := workloads.ParseDeploymentData(contract.DeploymentData)
 		if err != nil {
-			return workloads.K8sCluster{}, err
+			continue
 		}
 
-		checkIfExistAndAppend(t, contract.NodeID, contractID)
-		nodeIDs = append(nodeIDs, contract.NodeID)
+		// Only include contracts that belong to this specific cluster
+		// For K8s, the deployment name matches the cluster name
+		if deploymentData.Name == name {
+			contractID, err := strconv.ParseUint(contract.ContractID, 10, 64)
+			if err != nil {
+				continue
+			}
+
+			// Populate state with only the specific contracts we need
+			checkIfExistAndAppend(t, contract.NodeID, contractID)
+			nodeIDs = append(nodeIDs, contract.NodeID)
+		}
 	}
 
+	if len(nodeIDs) == 0 {
+		return workloads.K8sCluster{}, fmt.Errorf("no nodes found for cluster '%s' in project '%s'", name, projectName)
+	}
+
+	// Now LoadK8sFromGrid will work reliably
 	return t.State.LoadK8sFromGrid(ctx, nodeIDs, name)
 }
 
 // GetNetwork gets a network by project name and network name
 func GetNetwork(ctx context.Context, t deployer.TFPluginClient, projectName, networkName string) (workloads.ZNet, error) {
+	// Use targeted contract search instead of loading all user contracts
 	nodeContractIDs, err := t.ContractsGetter.GetNodeContractsByTypeAndName(projectName, workloads.NetworkType, networkName)
 	if err != nil {
-		return workloads.ZNet{}, err
+		return workloads.ZNet{}, fmt.Errorf("failed to find network contracts: %w", err)
 	}
 
 	if len(nodeContractIDs) == 0 {
 		return workloads.ZNet{}, fmt.Errorf("network '%s' not found in project '%s'", networkName, projectName)
 	}
 
-	// Populate state with contract IDs
-	for node, contractID := range nodeContractIDs {
-		checkIfExistAndAppend(t, node, contractID)
+	// Populate state with only the specific contracts we found
+	for nodeID, contractID := range nodeContractIDs {
+		checkIfExistAndAppend(t, nodeID, contractID)
 	}
 
-	return t.State.LoadNetworkFromGrid(ctx, networkName)
+	// Load network from grid
+	network, err := t.State.LoadNetworkFromGrid(ctx, networkName)
+	if err != nil {
+		return workloads.ZNet{}, fmt.Errorf("failed to get network %s: %w", networkName, err)
+	}
+
+	// Verify the network belongs to the expected project
+	if network.SolutionType != projectName {
+		return workloads.ZNet{}, fmt.Errorf("network '%s' found but belongs to project '%s', not '%s'", networkName, network.SolutionType, projectName)
+	}
+
+	return network, nil
 }
 
 // GetNetworkLight gets a light network by project name and network name
 func GetNetworkLight(ctx context.Context, t deployer.TFPluginClient, projectName, networkName string) (workloads.ZNetLight, error) {
+	// Use targeted contract search instead of loading all user contracts
 	nodeContractIDs, err := t.ContractsGetter.GetNodeContractsByTypeAndName(projectName, workloads.NetworkType, networkName)
 	if err != nil {
-		return workloads.ZNetLight{}, err
+		return workloads.ZNetLight{}, fmt.Errorf("failed to find network contracts: %w", err)
 	}
 
 	if len(nodeContractIDs) == 0 {
 		return workloads.ZNetLight{}, fmt.Errorf("network '%s' not found in project '%s'", networkName, projectName)
 	}
 
-	// Populate state with contract IDs
-	for node, contractID := range nodeContractIDs {
-		checkIfExistAndAppend(t, node, contractID)
+	// Populate state with only the specific contracts we found
+	for nodeID, contractID := range nodeContractIDs {
+		checkIfExistAndAppend(t, nodeID, contractID)
 	}
 
-	return t.State.LoadNetworkLightFromGrid(ctx, networkName)
+	// Load network from grid (using LoadNetworkFromGrid as it works better)
+	fullNetwork, err := t.State.LoadNetworkFromGrid(ctx, networkName)
+	if err != nil {
+		return workloads.ZNetLight{}, fmt.Errorf("failed to get network %s: %w", networkName, err)
+	}
+
+	// Convert ZNet to ZNetLight
+	network := workloads.ZNetLight{
+		Name:             fullNetwork.Name,
+		Description:      fullNetwork.Description,
+		Nodes:            fullNetwork.Nodes,
+		IPRange:          fullNetwork.IPRange,
+		SolutionType:     fullNetwork.SolutionType,
+		MyceliumKeys:     fullNetwork.MyceliumKeys,
+		PublicNodeID:     fullNetwork.PublicNodeID,
+		NodesIPRange:     fullNetwork.NodesIPRange,
+		NodeDeploymentID: fullNetwork.NodeDeploymentID,
+	}
+
+	// Verify the network belongs to the expected project
+	if network.SolutionType != projectName {
+		return workloads.ZNetLight{}, fmt.Errorf("network '%s' found but belongs to project '%s', not '%s'", networkName, network.SolutionType, projectName)
+	}
+
+	return network, nil
 }
 
 // GetGatewayName gets a gateway name by project name and gateway name
@@ -128,7 +187,8 @@ func GetGatewayName(ctx context.Context, t deployer.TFPluginClient, projectName,
 				continue
 			}
 
-			t.State.CurrentNodeDeployments[contract.NodeID] = []uint64{contractID}
+			// Populate state with only the specific contract we need
+			checkIfExistAndAppend(t, contract.NodeID, contractID)
 			nodeID = contract.NodeID
 			found = true
 			break
@@ -139,6 +199,7 @@ func GetGatewayName(ctx context.Context, t deployer.TFPluginClient, projectName,
 		return workloads.GatewayNameProxy{}, fmt.Errorf("no Gateway Name with name '%s' found in project '%s'", name, projectName)
 	}
 
+	// Now LoadGatewayNameFromGrid will work reliably
 	return t.State.LoadGatewayNameFromGrid(ctx, nodeID, name, name)
 }
 
@@ -167,7 +228,8 @@ func GetGatewayFQDN(ctx context.Context, t deployer.TFPluginClient, projectName,
 				continue
 			}
 
-			t.State.CurrentNodeDeployments[contract.NodeID] = []uint64{contractID}
+			// Populate state with only the specific contract we need
+			checkIfExistAndAppend(t, contract.NodeID, contractID)
 			nodeID = contract.NodeID
 			found = true
 			break
@@ -178,6 +240,7 @@ func GetGatewayFQDN(ctx context.Context, t deployer.TFPluginClient, projectName,
 		return workloads.GatewayFQDNProxy{}, fmt.Errorf("no Gateway FQDN with name '%s' found in project '%s'", name, projectName)
 	}
 
+	// Now LoadGatewayFQDNFromGrid will work reliably
 	return t.State.LoadGatewayFQDNFromGrid(ctx, nodeID, name, name)
 }
 
@@ -188,11 +251,17 @@ func GetDeployment(ctx context.Context, t deployer.TFPluginClient, projectName, 
 		return workloads.Deployment{}, err
 	}
 
+	if len(nodeContractIDs) == 0 {
+		return workloads.Deployment{}, fmt.Errorf("no contracts found for deployment '%s' in project '%s'", name, projectName)
+	}
+
 	var nodeID uint32
 	for node, contractID := range nodeContractIDs {
+		// Populate state with only the specific contract we need
 		checkIfExistAndAppend(t, node, contractID)
 		nodeID = node
 	}
 
+	// Now LoadDeploymentFromGrid will work reliably
 	return t.State.LoadDeploymentFromGrid(ctx, nodeID, name)
 }

--- a/grid-cli/internal/cmd/get.go
+++ b/grid-cli/internal/cmd/get.go
@@ -125,7 +125,9 @@ func GetGatewayName(ctx context.Context, t deployer.TFPluginClient, projectName,
 		}
 
 		// Check if this is the gateway we're looking for
-		if deploymentData.Name == name && deploymentData.Type == "gateway" {
+		// SDK uses workloads.GatewayNameType constant ("Gateway Name")
+		// Also check "gateway" for backward compatibility with old deployments
+		if deploymentData.Name == name && (deploymentData.Type == "gateway" || deploymentData.Type == workloads.GatewayNameType) {
 			contractID, err := strconv.ParseUint(contract.ContractID, 10, 64)
 			if err != nil {
 				continue
@@ -162,7 +164,9 @@ func GetGatewayFQDN(ctx context.Context, t deployer.TFPluginClient, projectName,
 		}
 
 		// Check if this is the gateway we're looking for
-		if deploymentData.Name == name && deploymentData.Type == "gateway" {
+		// SDK uses workloads.GatewayFQDNType constant ("Gateway Fqdn")
+		// Also check "gateway" for backward compatibility with old deployments
+		if deploymentData.Name == name && (deploymentData.Type == "gateway" || deploymentData.Type == workloads.GatewayFQDNType) {
 			contractID, err := strconv.ParseUint(contract.ContractID, 10, 64)
 			if err != nil {
 				continue

--- a/grid-cli/internal/cmd/validation.go
+++ b/grid-cli/internal/cmd/validation.go
@@ -1,0 +1,49 @@
+// Package cmd for handling commands
+package cmd
+
+import (
+	"strings"
+
+	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/deployer"
+	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
+)
+
+// DeploymentExists checks if a deployment with the given name already exists in the project
+func DeploymentExists(t deployer.TFPluginClient, projectName, deploymentName string) (bool, error) {
+	nodeContractIDs, err := t.ContractsGetter.GetNodeContractsByTypeAndName(projectName, workloads.VMType, deploymentName)
+	if err != nil {
+		// "could not find any contracts" means no deployment exists - this is not an error for our purpose
+		if strings.Contains(err.Error(), "could not find any contracts") {
+			return false, nil
+		}
+		return false, err
+	}
+	return len(nodeContractIDs) > 0, nil
+}
+
+// NetworkExistsForUser checks if a network with the given name already exists for this user (any project)
+// Returns: exists, projectName (if found), error
+func NetworkExistsForUser(t deployer.TFPluginClient, networkName string) (bool, string, error) {
+	contracts, err := t.ContractsGetter.ListContractsByTwinID([]string{"Created"})
+	if err != nil {
+		// No contracts at all means network doesn't exist
+		if strings.Contains(err.Error(), "could not find any contracts") {
+			return false, "", nil
+		}
+		return false, "", err
+	}
+
+	for _, contract := range contracts.NodeContracts {
+		deploymentData, err := workloads.ParseDeploymentData(contract.DeploymentData)
+		if err != nil {
+			continue
+		}
+
+		// Check if this is a network with the same name
+		if deploymentData.Type == workloads.NetworkType && deploymentData.Name == networkName {
+			return true, deploymentData.ProjectName, nil
+		}
+	}
+
+	return false, "", nil
+}

--- a/grid-cli/internal/filters/filters.go
+++ b/grid-cli/internal/filters/filters.go
@@ -43,13 +43,29 @@ func BuildVMFilter(disk workloads.Disk, volume workloads.Volume, farmID, memoryM
 	}
 
 	rootfss := []uint64{*convertGBToBytes(rootfsMB / 1024)}
-	return buildGenericFilter(&freeMRUs, &freeSRUs, nil, &freeIPs, []uint64{farmID}, nil, light), ssd, rootfss
+
+	// Handle farmID: 0 means any farm (empty slice), non-zero means specific farm
+	var farmFilter []uint64
+	if farmID != 0 {
+		farmFilter = []uint64{farmID}
+	} else {
+		farmFilter = []uint64{}
+	}
+
+	return buildGenericFilter(&freeMRUs, &freeSRUs, nil, &freeIPs, farmFilter, nil, light), ssd, rootfss
 }
 
 // BuildGatewayFilter build a filter for a gateway
 func BuildGatewayFilter(farmID uint64) types.NodeFilter {
+	var farmFilter []uint64
+	if farmID != 0 {
+		farmFilter = []uint64{farmID}
+	} else {
+		farmFilter = []uint64{}
+	}
+
 	domain := true
-	return buildGenericFilter(nil, nil, nil, nil, []uint64{farmID}, &domain, false)
+	return buildGenericFilter(nil, nil, nil, nil, farmFilter, &domain, false)
 }
 
 // BuildZDBFilter build a filter for a zdbs

--- a/knowledge/SOLUTIONS_CATALOG.md
+++ b/knowledge/SOLUTIONS_CATALOG.md
@@ -1,0 +1,1545 @@
+# ThreeFold Grid Solutions Catalogs
+
+This document provides a comprehensive list of all solutions supported in the ThreeFold Grid Playground weblets, including their configurations, requirements, and specifications.
+
+---
+
+## 1. Algorand
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/algorand-latest.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `NETWORK` | Optional | `mainnet` | Network type (mainnet/testnet/betanet/devnet) |
+| `NODE_TYPE` | Optional | `default` | Node type (default/relay/indexer) |
+
+### Proposed Specs
+
+- **CPU:** Variable based on node type (2-4 cores)
+- **Memory:** Variable based on node type (4-8 GB)
+- **Storage:** Variable based on node type (100-1500 GB)
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | 50 GB | `/var/lib/docker` | Yes (indexer only) |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Optional
+- **Gateway/Domain:** No
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+---
+
+## 2. Bitcoin Node
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/threefoldtech-tf_btcnode_30.0.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+
+### Proposed Specs
+
+- **Small:** CPU: 2, Memory: 4 GB, Disk: 50 GB
+- **Medium:** CPU: 4, Memory: 8 GB, Disk: 100 GB
+- **Large:** CPU: 8, Memory: 16 GB, Disk: 200 GB
+
+### Disk/Volumes
+
+No additional disks required (uses root filesystem).
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Required (at least one)
+- **Gateway/Domain:** No
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+---
+
+## 3. Caprover
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/tf-caprover-latest.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+#### Leader Node
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SWM_NODE_MODE` | Required | `leader` | Node mode |
+| `CAPROVER_ROOT_DOMAIN` | Required | - | Root domain for Caprover |
+| `CAPTAIN_IMAGE_VERSION` | Required | `latest` | Caprover version |
+| `PUBLIC_KEY` | Required | - | SSH public key |
+| `DEFAULT_PASSWORD` | Required | - | Admin password |
+| `CAPTAIN_IS_DEBUG` | Optional | `true` | Debug mode |
+
+#### Worker Nodes
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SWM_NODE_MODE` | Required | `worker` | Node mode |
+| `PUBLIC_KEY` | Required | - | SSH public key |
+
+### Proposed Specs
+
+Variable based on leader and worker configurations.
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/var/lib/docker` | Yes |
+
+### Additional Requirements
+
+- **IPv4:** Required for leader
+- **Gateway/Domain:** Yes (required)
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+### Notes
+
+**Multi-Node Architecture:**
+
+- Caprover supports a **leader + workers** cluster architecture
+- All nodes (leader and workers) should deployed on the **same private network**
+
+**Network Linking:**
+
+- Leader and workers communicate via the private network (WireGuard)
+- Workers discover the leader automatically through the shared network
+
+**Deployment Flow:**
+
+1. Create a single network for the entire cluster
+2. Deploy leader node with `SWM_NODE_MODE=leader`
+3. Deploy worker nodes with `SWM_NODE_MODE=worker` on the same network
+4. All nodes share the same deployment name and network configuration
+
+**DNS Requirements:**
+
+- Wildcard DNS record required: `*.yourdomain.com` → Leader's public IPv4
+- Example: If domain is `example.com`, set DNS: `*.example.com` → `185.x.x.x`
+- This allows Caprover to create subdomains for each deployed app
+
+**Special Handling:**
+
+- Leader requires public IPv4 (mandatory)
+- Workers can use private IPs only
+- Each node gets its own disk mounted at `/var/lib/docker`
+- SSH keys are shared across all nodes
+
+---
+
+## 4. Casperlabs
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/casperlabs-latest.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `CASPERLABS_HOSTNAME` | Required | - | Hostname/domain |
+| `KNOWN_VALIDATOR_IP` | Optional | `3.14.161.135` | Known validator IP |
+
+### Proposed Specs
+
+- **Small:** CPU: 2, Memory: 4 GB, Disk: 100 GB
+- **Medium:** CPU: 4, Memory: 16 GB, Disk: 500 GB
+- **Large:** CPU: 8, Memory: 32 GB, Disk: 1000 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/data` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Optional
+- **Gateway/Domain:** Yes (required)
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+---
+
+## 5. Discourse
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/forum.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `DISCOURSE_HOSTNAME` | Required | - | Hostname/domain |
+| `DISCOURSE_DEVELOPER_EMAILS` | Required | - | Admin email |
+| `DISCOURSE_SMTP_ADDRESS` | Required | - | SMTP server address |
+| `DISCOURSE_SMTP_PORT` | Required | - | SMTP server port |
+| `DISCOURSE_SMTP_ENABLE_START_TLS` | Required | - | Enable TLS (true/false) |
+| `DISCOURSE_SMTP_USER_NAME` | Required | - | SMTP username |
+| `DISCOURSE_SMTP_PASSWORD` | Required | - | SMTP password |
+| `THREEBOT_PRIVATE_KEY` | Required | - | ED25519 base64 private key |
+| `FLASK_SECRET_KEY` | Required | - | Flask secret |
+
+### Proposed Specs
+
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 50 GB
+- **Large:** CPU: 4, Memory: 16 GB, Disk: 100 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/var/lib/docker` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Optional
+- **Gateway/Domain:** Yes (required)
+- **SMTP:** Required
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+---
+
+## 6. Freeflow
+
+**Flist URL:** `https://hub.grid.tf/lennertapp2.3bot/threefoldjimber-freeflow-latest.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `USER_ID` | Required | - | 3Bot name |
+| `DIGITALTWIN_APPID` | Required | - | Domain |
+| `NODE_ENV` | Required | `staging` | Environment |
+
+### Proposed Specs
+
+- **Small:** CPU: 1, Memory: 4 GB, Disk: 100 GB
+- **Medium:** CPU: 2, Memory: 16 GB, Disk: 500 GB
+- **Large:** CPU: 4, Memory: 32 GB, Disk: 1000 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/disk` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Required (at least one)
+- **Gateway/Domain:** Yes (required)
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+---
+
+## 7. Ubuntu OS Images
+
+**Flist URLs:**
+
+- Ubuntu 24.04: `https://hub.grid.tf/tf-official-vms/ubuntu-24.04-full.flist`
+- Ubuntu 22.04: `https://hub.grid.tf/tf-official-vms/ubuntu-22.04.flist`
+- Ubuntu 20.04: `https://hub.grid.tf/tf-official-vms/ubuntu-20.04-lts.flist`
+- Ubuntu 18.04: `https://hub.grid.tf/tf-official-vms/ubuntu-18.04-lts.flist`
+
+**Entry Point:** `` (empty)
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+
+### Proposed Specs
+
+- **Micro:** CPU: 1, Memory: 0.5 GB, Disk: 20 GB
+- **Small:** CPU: 1, Memory: 2 GB, Disk: 25 GB
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 50 GB
+- **Large:** CPU: 4, Memory: 16 GB, Disk: 100 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/` or custom | Optional (additional disks) |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Required (at least one)
+- **Gateway/Domain:** No
+- **GPU:** Optional
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+### Notes
+
+**Use Cases:**
+
+- Development environments
+- Production servers
+- GPU computing (ML/AI workloads)
+- Custom application hosting
+
+---
+
+## 8. Funkwhale
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/funkwhale-1.4.0.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `FUNKWHALE_HOSTNAME` | Required | - | Hostname/domain |
+| `FUNKWHALE_SUPERUSER_EMAIL` | Required | - | Admin email |
+| `FUNKWHALE_SUPERUSER_USERNAME` | Required | - | Admin username |
+| `FUNKWHALE_SUPERUSER_PASSWORD` | Required | - | Admin password |
+
+### Proposed Specs
+
+- **Small:** CPU: 1, Memory: 2 GB, Disk: 50 GB
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 100 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/data` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Optional
+- **Gateway/Domain:** Yes (required)
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+---
+
+## 9. Gitea
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/gitea-mycelium.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `GITEA__HOSTNAME` | Required | - | Hostname/domain |
+| `GITEA__mailer__PROTOCOL` | Optional | `smtp` | Mail protocol |
+| `GITEA__mailer__ENABLED` | Optional | `false` | Enable mailer |
+| `GITEA__mailer__HOST` | Optional | `smtp.gmail.com` | SMTP host |
+| `GITEA__mailer__FROM` | Optional | - | From email |
+| `GITEA__mailer__PORT` | Optional | `587` | SMTP port |
+| `GITEA__mailer__USER` | Optional | - | SMTP username |
+| `GITEA__mailer__PASSWD` | Optional | - | SMTP password |
+
+### Proposed Specs
+
+- **Small:** CPU: 1, Memory: 2 GB, Disk: 25 GB
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 50 GB
+- **Large:** CPU: 4, Memory: 16 GB, Disk: 100 GB
+
+### Disk/Volumes
+
+No additional disks required (uses root filesystem).
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Required (at least one)
+- **Gateway/Domain:** Yes (required)
+- **SMTP:** Optional
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+---
+
+## 10. Jenkins
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/jenkins-latest.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `JENKINS_HOSTNAME` | Required | - | Hostname/domain |
+| `JENKINS_ADMIN_USERNAME` | Required | - | Admin username |
+| `JENKINS_ADMIN_PASSWORD` | Required | - | Admin password |
+
+### Proposed Specs
+
+- **Small:** CPU: 2, Memory: 4 GB, Disk: 50 GB
+- **Medium:** CPU: 4, Memory: 8 GB, Disk: 500 GB
+- **Large:** CPU: 4, Memory: 16 GB, Disk: 1000 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/data` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Optional
+- **Gateway/Domain:** Yes (required)
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+---
+
+## 11. Jitsi
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/jitsi-latest.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `JITSI_HOSTNAME` | Required | - | Hostname/domain |
+
+### Proposed Specs
+
+- **Small:** CPU: 2, Memory: 4 GB, Disk: 100 GB
+- **Medium:** CPU: 4, Memory: 16 GB, Disk: 500 GB
+- **Large:** CPU: 8, Memory: 32 GB, Disk: 1000 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/data` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Required (at least one)
+- **Gateway/Domain:** Yes (required)
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+---
+
+## 12. Kubernetes
+
+**Flist URL:** Uses same flist as micro VMs (varies by OS)
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+
+### Proposed Specs
+
+Variable based on master and worker configurations.
+
+### Disk/Volumes
+
+Variable based on configuration.
+
+### Additional Requirements
+
+- **IPv4:** Required for master
+- **Gateway/Domain:** No
+- **Cluster Token:** Required (6-15 characters)
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+### Notes
+
+**Cluster Architecture:**
+
+- Kubernetes supports a **master + workers** cluster architecture
+- All nodes are deployed on the **same private network**
+- Master and workers communicate via the shared network
+
+**Special Requirements:**
+
+- Master node requires public IPv4 for external access
+- Cluster token acts as authentication between nodes
+- SSH key is mandatory (not optional) for cluster management
+- Each node can have different resource specifications
+
+**Use Cases:**
+
+- Container orchestration
+- Microservices deployment
+- Scalable application hosting
+
+---
+
+## 13. Mattermost
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/mattermost-latest.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `DB_PASSWORD` | Required | - | Database password |
+| `SITE_URL` | Required | - | Site URL (<https://domain>) |
+| `MATTERMOST_DOMAIN` | Required | - | Domain |
+| `SMTPUsername` | Optional | - | SMTP username |
+| `SMTPPassword` | Optional | - | SMTP password |
+| `SMTPServer` | Optional | - | SMTP server |
+| `SMTPPort` | Optional | - | SMTP port |
+
+### Proposed Specs
+
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 50 GB
+- **Large:** CPU: 4, Memory: 16 GB, Disk: 100 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/var/lib/docker` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Optional (IPv4 required if SMTP enabled)
+- **Gateway/Domain:** Yes (required)
+- **SMTP:** Optional
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+---
+
+## 14. Micro Virtual Machine
+
+**Flist URLs and Entry Points:**
+
+- Ubuntu 24.04: `https://hub.grid.tf/tf-official-vms/ubuntu-24.04-latest.flist` - Entry Point: `/sbin/zinit init`
+- Ubuntu 23.10: `https://hub.grid.tf/tf-official-vms/ubuntu-23.10-mycelium.flist` - Entry Point: `/sbin/zinit init`
+- Ubuntu 22.04: `https://hub.grid.tf/tf-official-apps/threefoldtech-ubuntu-22.04.flist` - Entry Point: `/sbin/zinit init`
+- Debian 12: `https://hub.grid.tf/tf-official-apps/debian12.flist` - Entry Point: `/sbin/zinit init`
+- CentOS 9: `https://hub.grid.tf/tf-official-apps/centos-stream9.flist` - Entry Point: `/entrypoint.sh`
+- Arch: `https://hub.grid.tf/petep.3bot/archlinux_20240101.0.204074.flist` - Entry Point: `/sbin/zinit init`
+- Alpine 3: `https://hub.grid.tf/tf-official-apps/alpine3.flist` - Entry Point: `/entrypoint.sh`
+
+### Environment Variables
+
+Custom environment variables can be defined.
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+
+### Proposed Specs
+
+- **Micro:** CPU: 1, Memory: 0.5 GB, Disk: 20 GB
+- **Small:** CPU: 1, Memory: 2 GB, Disk: 25 GB
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 50 GB
+- **Large:** CPU: 4, Memory: 16 GB, Disk: 100 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | Custom | Optional (additional disks) |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Required (at least one)
+- **Gateway/Domain:** No
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+### Notes
+
+**Custom Environment Variables:**
+
+- Unlike other solutions, Micro VMs allow you to define **any custom environment variables**
+- Useful for passing configuration to your applications
+- Variables are injected into the VM at boot time
+
+---
+
+## 15. Nextcloud
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/nextcloud.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `NEXTCLOUD_DOMAIN` | Required | - | Domain |
+| `NEXTCLOUD_AIO_LINK` | Required | - | AIO link (domain/aio) |
+| `GATEWAY` | Required | - | Has gateway (true/false) |
+| `IPV4` | Required | - | Has IPv4 (true/false) |
+
+### Proposed Specs
+
+- **Small:** CPU: 2, Memory: 4 GB, Disk: 50 GB
+- **Medium:** CPU: 4, Memory: 8 GB, Disk: 500 GB
+- **Large:** CPU: 4, Memory: 16 GB, Disk: 1000 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/mnt/data` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Optional
+- **Gateway/Domain:** Yes (required)
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+### Notes
+
+**Nextcloud AIO (All-in-One):**
+
+- This deployment uses Nextcloud AIO, which includes:
+  - Nextcloud server
+  - Database (PostgreSQL)
+  - Redis cache
+  - Full-text search
+  - Backup solution
+  - All in one container
+
+**Access Setup:**
+
+- Access Nextcloud via: `https://yourdomain.com`
+- Access AIO admin interface via: `https://yourdomain.com/aio`
+- AIO interface is used for initial setup and configuration
+
+**Environment Variables:**
+
+- `NEXTCLOUD_DOMAIN`: Your full domain
+- `NEXTCLOUD_AIO_LINK`: Domain with `/aio` path for admin
+- `GATEWAY`: Set to `true` if using gateway
+- `IPV4`: Set to `true` if node has public IPv4
+
+**Storage:**
+
+- Large disk recommended (500GB - 1TB)
+- All data stored in `/mnt/data`
+- Includes files, database, and backups
+
+**First-Time Setup:**
+
+1. Deploy the instance
+2. Access the AIO interface at `yourdomain.com/aio`
+3. Complete the initial configuration wizard
+4. Set admin password and configure apps
+
+---
+
+## 16. Node Pilot
+
+**Flist URL:** `https://hub.grid.tf/tf-official-vms/node-pilot-zdbfs.flist`
+
+**Entry Point:** `/`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `NODE_PILOT_HOSTNAME` | Required | - | Hostname/domain |
+
+### Proposed Specs
+
+- **Small:** CPU: 4, Memory: 8 GB, Disk: 500 GB
+- **Medium:** CPU: 8, Memory: 16 GB, Disk: 1000 GB
+- **Large:** CPU: 8, Memory: 32 GB, Disk: 2000 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/` | Yes |
+
+### Additional Requirements
+
+- **IPv4:** Required
+- **IPv6:** Required
+- **Gateway/Domain:** Yes (required)
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+---
+
+## 17. Nostr
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/nostr_relay-mycelium.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `NOSTR_HOSTNAME` | Required | - | Hostname/domain |
+
+### Proposed Specs
+
+- **Small:** CPU: 1, Memory: 2 GB, Disk: 25 GB
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 50 GB
+- **Large:** CPU: 4, Memory: 16 GB, Disk: 100 GB
+
+### Disk/Volumes
+
+No additional disks required (uses root filesystem).
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Required (at least one)
+- **Gateway/Domain:** Yes (required)
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+---
+
+## 18. Open WebUI
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/threefoldtech-ubuntu-24.04_fullvm_oi.flist`
+
+**Entry Point:** `` (empty)
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `OPENWEBUI_DOMAIN` | Required | - | Domain |
+
+### Proposed Specs
+
+- **Small:** CPU: 4, Memory: 16 GB, Disk: 125 GB
+- **Medium:** CPU: 8, Memory: 32 GB, Disk: 250 GB
+- **Large:** CPU: 16, Memory: 64 GB, Disk: 500 GB
+
+### Disk/Volumes
+
+No additional disks required (uses root filesystem).
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Required (at least one)
+- **Gateway/Domain:** Yes (required)
+- **GPU:** Optional
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+### Notes
+
+**GPU Support for AI:**
+
+- Open WebUI supports GPU passthrough for AI model inference
+- GPU significantly improves performance for large language models
+- Requires dedicated node with GPU when using GPU features
+- GPU is optional - CPU-only deployment is also supported
+
+**AI Model Hosting:**
+
+- Compatible with Ollama for running local AI models
+- Can run models like Llama, Mistral, CodeLlama, etc.
+- GPU recommended for models larger than 7B parameters
+- CPU-only works for smaller models (3B-7B)
+
+**Resource Requirements:**
+
+- Minimum: 4 CPU, 16 GB RAM (for small models)
+- Recommended: 8+ CPU, 32+ GB RAM, GPU (for large models)
+- Large disk space for model storage (125GB+)
+
+**Use Cases:**
+
+- Private AI assistant deployment
+- Local LLM experimentation
+- AI-powered applications
+- Privacy-focused AI hosting
+
+---
+
+## 19. Owncloud
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/owncloud-10.9.1.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `OWNCLOUD_ADMIN_USERNAME` | Required | - | Admin username |
+| `OWNCLOUD_ADMIN_PASSWORD` | Required | - | Admin password |
+| `OWNCLOUD_DOMAIN` | Required | - | Domain |
+| `OWNCLOUD_MAIL_SMTP_SECURE` | Optional | - | SMTP security (tls/ssl/none) |
+| `OWNCLOUD_MAIL_FROM_ADDRESS` | Optional | - | From email address |
+| `OWNCLOUD_MAIL_DOMAIN` | Optional | - | Mail domain |
+| `OWNCLOUD_MAIL_SMTP_HOST` | Optional | - | SMTP host |
+| `OWNCLOUD_MAIL_SMTP_PORT` | Optional | - | SMTP port |
+| `OWNCLOUD_MAIL_SMTP_NAME` | Optional | - | SMTP username |
+| `OWNCLOUD_MAIL_SMTP_PASSWORD` | Optional | - | SMTP password |
+
+### Proposed Specs
+
+- **Small:** CPU: 2, Memory: 8 GB, Disk: 250 GB
+- **Medium:** CPU: 4, Memory: 16 GB, Disk: 500 GB
+- **Large:** CPU: 8, Memory: 32 GB, Disk: 1000 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/var/lib/docker` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Optional
+- **Gateway/Domain:** Yes (required)
+- **SMTP:** Optional
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+---
+
+## 20. Peertube
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/peertube-latest.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `PEERTUBE_ADMIN_EMAIL` | Required | - | Admin email |
+| `PT_INITIAL_ROOT_PASSWORD` | Required | - | Admin password |
+| `PEERTUBE_WEBSERVER_HOSTNAME` | Required | - | Hostname/domain |
+
+### Proposed Specs
+
+Uses standard solution flavors (Small/Medium/Large).
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/data` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Optional
+- **Gateway/Domain:** Yes (required)
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+---
+
+## 21. Presearch
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/presearch.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `PRESEARCH_REGISTRATION_CODE` | Required | - | Registration code (32 chars) |
+| `PRESEARCH_BACKUP_PRI_KEY` | Optional | - | Private restore key |
+| `PRESEARCH_BACKUP_PUB_KEY` | Optional | - | Public restore key |
+
+### Proposed Specs
+
+- **CPU:** 1
+- **Memory:** 512 MB
+- **Root Filesystem:** Calculated
+- **Docker Disk:** 10 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | 10 GB | `/var/lib/docker` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Required (at least one)
+- **Gateway/Domain:** No
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+### Notes
+
+**Farm Limitations:**
+
+- **Important:** Only **one Presearch node per farm** is allowed without a dedicated public IP
+- If deploying multiple nodes, each must have its own public IPv4
+- This is a Presearch network requirement, not a Grid limitation
+
+**Restore Keys:**
+
+- Private and public restore keys are optional but recommended
+- These keys allow you to restore your node if redeployed
+- Without restore keys, you'll need to re-register with Presearch
+
+**Registration:**
+
+- Registration code (32 characters) is mandatory
+- Obtain from Presearch dashboard before deployment
+- Each node requires a unique registration code
+
+**Resource Requirements:**
+
+- Minimal resources: 1 CPU, 512 MB RAM
+- Small disk requirement: 10 GB for Docker
+- Suitable for low-resource nodes
+
+---
+
+## 22. Static Website
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/staticwebsite-latest.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `GITHUB_URL` | Required | - | Git repository URL (https) |
+| `GITHUB_BRANCH` | Optional | - | Git branch name |
+| `HTML_DIR` | Optional | `website` | HTML directory path |
+| `USER_DOMAIN` | Optional | - | Custom domain |
+| `STATICWEBSITE_DOMAIN` | Required | - | Domain |
+
+### Proposed Specs
+
+- **Small:** CPU: 1, Memory: 2 GB, Disk: 50 GB
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 100 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/var/lib/docker` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Optional
+- **Gateway/Domain:** Yes (required)
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+---
+
+## 23. Subsquid
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/subsquid.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `CHAIN_ENDPOINT` | Required | - | Websocket endpoint (wss://) |
+| `SUBSQUID_WEBSERVER_HOSTNAME` | Required | - | Hostname/domain |
+
+### Proposed Specs
+
+- **Small:** CPU: 1, Memory: 2 GB, Disk: 50 GB
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 100 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/var/lib/docker` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Optional
+- **Gateway/Domain:** Yes (required)
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+---
+
+## 24. Taiga
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/grid3_taiga_docker-latest.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `DOMAIN_NAME` | Required | - | Domain |
+| `ADMIN_USERNAME` | Required | - | Admin username |
+| `ADMIN_PASSWORD` | Required | - | Admin password |
+| `ADMIN_EMAIL` | Required | - | Admin email |
+| `EMAIL_HOST` | Optional | - | SMTP host |
+| `EMAIL_PORT` | Optional | - | SMTP port |
+| `EMAIL_HOST_USER` | Optional | - | SMTP username |
+| `EMAIL_HOST_PASSWORD` | Optional | - | SMTP password |
+| `EMAIL_USE_TLS` | Optional | - | Use TLS (True/False) |
+| `EMAIL_USE_SSL` | Optional | - | Use SSL (True/False) |
+
+### Proposed Specs
+
+- **Small:** CPU: 2, Memory: 4 GB, Disk: 100 GB
+- **Medium:** CPU: 4, Memory: 8 GB, Disk: 150 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/var/lib/docker` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Optional (IPv4 required if SMTP enabled)
+- **Gateway/Domain:** Yes (required)
+- **SMTP:** Optional
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+---
+
+## 25. TFRobot
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/tfrobot.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+Custom environment variables can be defined.
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+
+### Proposed Specs
+
+- **Small:** CPU: 1, Memory: 2 GB, Disk: 25 GB
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 50 GB
+- **Large:** CPU: 4, Memory: 16 GB, Disk: 100 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | Custom | Optional (additional disks) |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Required (at least one)
+- **Gateway/Domain:** No
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+### Notes
+
+**Flexible Deployment:**
+
+- TFRobot is a **generic VM template** for custom deployments
+- Allows you to define custom environment variables
+- Supports multiple disks with custom mount points
+- Most flexible solution for advanced users
+
+**Custom Configuration:**
+
+- Define any environment variables needed for your application
+- Add as many disks as needed
+- Specify custom mount points for each disk
+- Full control over VM configuration
+
+**Use Cases:**
+
+- Custom application deployment
+- Testing new services
+- Advanced configurations not covered by other solutions
+- Prototype development
+
+---
+
+## 26. Umbrel
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/umbrel-latest.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `USERNAME` | Required | - | Admin username |
+| `PASSWORD` | Required | - | Admin password |
+| `UMBREL_DISK` | Required | `/umbrelDisk` | Umbrel disk path |
+
+### Proposed Specs
+
+- **Small:** CPU: 1, Memory: 2 GB, Disk: 10 GB
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 50 GB
+- **Large:** CPU: 4, Memory: 16 GB, Disk: 100 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | 10 GB | `/var/lib/docker` | Yes |
+| SSD | Variable | `/umbrelDisk` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Required (at least one)
+- **Gateway/Domain:** No
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+---
+
+## 27. Wordpress
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/tf-wordpress-latest.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `MYSQL_USER` | Required | - | MySQL username |
+| `MYSQL_PASSWORD` | Required | - | MySQL password |
+| `ADMIN_EMAIL` | Required | - | Admin email |
+| `WP_URL` | Required | - | WordPress URL/domain |
+
+### Proposed Specs
+
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 50 GB
+- **Large:** CPU: 4, Memory: 16 GB, Disk: 100 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/var/www/html` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Optional
+- **Gateway/Domain:** Yes (required)
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+---
+
+## 28. Aydo
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/aydo-latest.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+
+### Proposed Specs
+
+- **Small:** CPU: 1, Memory: 2 GB, Disk: 25 GB
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 50 GB
+- **Large:** CPU: 4, Memory: 8 GB, Disk: 100 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/data` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Required (for Aydo to work with ONLYOFFICE)
+- **Gateway/Domain:** Yes (required)
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+**Use Cases:**
+
+- Aydo application deployment
+- ONLYOFFICE document collaboration
+- Web-based office applications
+
+---
+
+## 29. Dagu
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/dagu-latest.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `DAGU_USERNAME` | Optional | `admin` | Dagu UI username |
+| `DAGU_PASSWORD` | Optional | `password` | Dagu UI password |
+| `CODE_SERVER_PASSWORD` | Optional | `password` | Code server access password |
+| `HOMEIP` | Optional | - | IP address for hero callback |
+
+### Proposed Specs
+
+- **Small:** CPU: 1, Memory: 2 GB, Disk: 25 GB
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 50 GB
+- **Large:** CPU: 4, Memory: 8 GB, Disk: 100 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/data` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Optional
+- **Gateway/Domain:** No
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+**Use Cases:**
+
+- Workflow automation and orchestration
+- Cron job management
+- DAG-based task scheduling
+- Code server for remote development
+
+---
+
+## 30. Hero
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/hero-latest.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+
+### Proposed Specs
+
+- **Small:** CPU: 1, Memory: 2 GB, Disk: 25 GB
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 50 GB
+- **Large:** CPU: 4, Memory: 8 GB, Disk: 100 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/data` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Optional
+- **Gateway/Domain:** No
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+**Use Cases:**
+
+- Hero framework development
+- Go language development environment
+- ThreeFold ecosystem development
+- Build and deployment automation
+
+---
+
+## 31. IPFS Cluster
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/ipfs-cluster-latest.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `CLUSTER_SECRET` | Optional | - | Cluster secret (same for all peers) |
+| `BOOTSTRAP` | Optional | - | Bootstrap peer address for joining cluster |
+| `IPFS_PROFILE` | Optional | `server` | IPFS profile optimization |
+| `CLUSTER_PINSVCAPI_HTTPLISTENMULTIADDRESS` | Optional | `/ip4/0.0.0.0/tcp/9097` | Pin service REST endpoint |
+| `CLUSTER_RESTAPI_HTTPLISTENMULTIADDRESS` | Optional | `/ip4/0.0.0.0/tcp/9094` | Cluster REST API endpoint |
+
+### Proposed Specs
+
+- **Small:** CPU: 1, Memory: 2 GB, Disk: 50 GB
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 100 GB
+- **Large:** CPU: 4, Memory: 8 GB, Disk: 200 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/data` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Required (for cluster communication)
+- **Gateway/Domain:** No
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+**Use Cases:**
+
+- Distributed file storage
+- IPFS cluster deployment
+- Content pinning services
+- Peer-to-peer file sharing
+
+---
+
+## 32. Mastodon
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/mastodon-latest.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `LOCAL_DOMAIN` | Required | - | Domain name for Mastodon instance |
+| `SUPERUSER_EMAIL` | Required | - | Admin email for Mastodon |
+| `SUPERUSER_USERNAME` | Required | - | Admin username |
+| `SUPERUSER_PASSWORD` | Required | - | Admin password |
+| `IS_TF_CONNECT` | Optional | `false` | Enable ThreeFold Connect authenticator |
+| `RELAYS_LINKS` | Optional | - | List of relay links for Fediverse |
+| `SMTP_SERVER` | Optional | - | SMTP server address |
+| `SMTP_PORT` | Optional | `587` | SMTP server port |
+| `SMTP_LOGIN` | Optional | - | SMTP username |
+| `SMTP_PASSWORD` | Optional | - | SMTP password |
+| `SMTP_FROM_ADDRESS` | Optional | - | SMTP from address |
+
+### Proposed Specs
+
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 100 GB
+- **Large:** CPU: 4, Memory: 8 GB, Disk: 200 GB
+- **Extra Large:** CPU: 8, Memory: 16 GB, Disk: 500 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/var/lib/docker` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Required (for Fediverse communication)
+- **Gateway/Domain:** Yes (required)
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+**Use Cases:**
+
+- Social media platform deployment
+- Fediverse instance hosting
+- Community communication platform
+- Decentralized social networking
+
+---
+
+## 33. Monitor
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/monitor-latest.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `PROM_TARGETS` | Optional | - | Comma-separated hosts for Prometheus to scrape |
+
+### Proposed Specs
+
+- **Small:** CPU: 1, Memory: 2 GB, Disk: 25 GB
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 50 GB
+- **Large:** CPU: 4, Memory: 8 GB, Disk: 100 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/data` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Optional
+- **Gateway/Domain:** No
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+**Use Cases:**
+
+- System monitoring and alerting
+- Metrics collection and visualization
+- Grafana dashboard deployment
+- Prometheus monitoring setup
+
+---
+
+## 34. Nomad
+
+**Flist URL:** `https://hub.grid.tf/tf-official-apps/nomad-latest.flist`
+
+**Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+| `FIRST_SERVER_IP` | Optional | - | Private IP of first server (for cluster joining) |
+| `NOMAD_SERVERS` | Optional | `1` | Number of expected Nomad servers |
+
+### Proposed Specs
+
+- **Small:** CPU: 1, Memory: 2 GB, Disk: 25 GB
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 50 GB
+- **Large:** CPU: 4, Memory: 8 GB, Disk: 100 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/data` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Optional
+- **Gateway/Domain:** No
+- **Planetary Network:** Optional
+- **Mycelium:** Optional
+
+**Use Cases:**
+
+- Container orchestration
+- Workload scheduling
+- Service deployment automation
+- Distributed system management
+
+---
+
+## 35. Base OS Images (Additional)
+
+**Flist URLs:**
+
+- Alpine Linux: `https://hub.grid.tf/tf-official-apps/threefoldtech-alpine-3.flist` - **Entry Point:** `/entrypoint.sh`
+- Arch Linux (Mycelium): `https://hub.grid.tf/tf-official-apps/arch-mycelium-latest.flist` - **Entry Point:** `/sbin/zinit init`
+- CentOS 9: `https://hub.grid.tf/tf-official-apps/centos-9-latest.flist` - **Entry Point:** `/sbin/zinit init`
+- Debian Linux: `https://hub.grid.tf/tf-official-apps/threefoldtech-debian-12.flist` - **Entry Point:** `/sbin/zinit init`
+- Docker with SSH: `https://hub.grid.tf/tf-official-apps/docker-ssh-latest.flist` - **Entry Point:** `/sbin/zinit init`
+- NixOS: `https://hub.grid.tf/tf-official-apps/nixos-latest.flist` - **Entry Point:** `/sbin/zinit init`
+
+### Environment Variables
+
+| Variable | Type | Proposed Default Value | Description |
+|----------|------|---------|-------------|
+| `SSH_KEY` | Required | - | SSH public key for access |
+
+### Proposed Specs
+
+- **Micro:** CPU: 1, Memory: 1 GB, Disk: 10 GB
+- **Small:** CPU: 1, Memory: 2 GB, Disk: 25 GB
+- **Medium:** CPU: 2, Memory: 4 GB, Disk: 50 GB
+
+### Disk/Volumes
+
+| Type | Size | Mount Point | Required |
+|------|------|-------------|----------|
+| SSD | Variable | `/` | Yes |
+
+### Additional Requirements
+
+- **IPv4/IPv6:** Optional
+- **Gateway/Domain:** No
+- **Planetary Network:** Optional
+- **Mycelium:** Optional (except Arch Mycelium variant)
+
+**Use Cases:**
+
+- Custom application deployment
+- Development environments
+- Lightweight virtual machines
+- Container hosting platforms
+
+---
+
+## Summary
+
+This catalog contains **35 different solutions** available on the ThreeFold Grid, ranging from blockchain nodes to full-featured applications, base operating systems, and virtual machines. Each solution has specific requirements for:
+
+- **Compute Resources:** CPU, Memory, and Storage
+- **Network Configuration:** IPv4, IPv6, Planetary Network, Mycelium
+- **Gateway/Domain:** Some solutions require domain configuration
+- **Additional Services:** SMTP, GPU support, etc.
+
+All solutions support SSH key authentication and can be deployed with various resource configurations to match different use cases.


### PR DESCRIPTION
This PR contains significant improvements to grid-cli, grid-agent-gui, and the LLM agent, focusing on clearer project management, better gateway deployments, and enhanced user experience.

## Breaking Changes ⚠️
- All `get` and  `cancel` commands now require `--project-name` flag
  - Old: tfcmd get vm myvm
  -  New: tfcmd get vm myvm --project-name vm/myvm

## Features
**Grid CLI**
- Required --project-name flag for all get/cancel commands (eliminates unreliable project name guessing)
- Auto-extend network to gateway node when --network flag is provided
- Deployment/network uniqueness validation before deployment
- Granular VM cancellation with --vm flag for multi-VM projects
- List gateways command (tfcmd list gateways name/fqdn)
- Multiple disks per VM support with custom mount points
- Default --disable-sentry to true for cleaner output

**Grid Agent GUI**
- LLM session history carry-over across profile/model changes
- Improved Settings UI with grid and AI configuration sections
- Profile management (activate, deactivate, update)
- Context markers when switching profiles/network

**Agent/LLM**
- Simplified JSON response format (single object instead of array)
- Improved tool instructions with validation checklist

**Documentation**
- Added cancel.md, get.md, login.md, update.md, version.md, list.md
- Updated vm.md, gateway-name.md, gateway-fqdn.md with new flag requirements
- Added SOLUTIONS_CATALOG.md with flist URLs, env vars, and specs for all solutions
